### PR TITLE
fix(bcrypt tool): allow salt rounds up to 100 (#987)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'pnpm'
 
       - name: Get Playwright version

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ const useWebServer = process.env.NO_WEB_SERVER !== 'true';
  */
 export default defineConfig({
   testDir: './src',
-  testMatch: /.*\.e2e\.(spec\.)?ts/,
+  testMatch: /\.e2e\.(spec\.)?ts$/,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -57,7 +57,7 @@ export default defineConfig({
     && {
       webServer: {
         command: 'npm run preview',
-        url: 'http://127.0.0.1:5050',
+        url: 'http://localhost:5050',
         reuseExistingServer: !isCI,
       },
     }

--- a/src/tools/bcrypt/bcrypt.vue
+++ b/src/tools/bcrypt/bcrypt.vue
@@ -28,7 +28,7 @@ const compareMatch = computed(() => compareSync(compareString.value, compareHash
       mb-2
     />
     <n-form-item label="Salt count: " label-placement="left" label-width="120">
-      <n-input-number v-model:value="saltCount" placeholder="Salt rounds..." :max="10" :min="0" w-full />
+      <n-input-number v-model:value="saltCount" placeholder="Salt rounds..." :max="100" :min="0" w-full />
     </n-form-item>
 
     <c-input-text :value="hashed" readonly text-center />


### PR DESCRIPTION
* fix(bcrypt tool): allow salt rounds up to 100

Previously max salt rounds was 10

* chore(github workflows): ci and e2e tests: try updating to node 20