### PR TITLE
Fix ESLint configuration: remove invalid ts/semi rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,8 +22,7 @@ export default antfu(
   {
     rules: {
       'curly': ['error', 'all'],
-      'ts/semi': ['error', 'always'],
-      'ts/no-use-before-define': ['error', { allowNamedExports: true, functions: false }],
+      '@typescript-eslint/no-use-before-define': ['error', { allowNamedExports: true, functions: false }],
       'vue/no-empty-component-block': ['error'],
       'no-restricted-imports': ['error', {
         paths: [{


### PR DESCRIPTION
The ts/semi rule doesn't exist in the TypeScript ESLint plugin as
stylistic rules have been moved to ESLint Stylistic. The semicolon
enforcement is already handled by the stylistic configuration with
`stylistic: { semi: true }`.

Also updated ts/no-use-before-define to use the correct plugin prefix
@typescript-eslint/no-use-before-define.

Fixes #323