### PR TITLE
fix: group related dependencies in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,80 @@
       "groupName": "TypeScript toolchain",
       "matchPackageNames": ["typescript", "vue-tsc"],
       "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "Vue ecosystem",
+      "matchPackageNames": [
+        "vue",
+        "@vue/compiler-sfc",
+        "@vue/runtime-dom",
+        "@vue/test-utils",
+        "@vue/tsconfig"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "Vite ecosystem",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-vue",
+        "@vitejs/plugin-vue-jsx",
+        "vite-plugin-pwa",
+        "vite-plugin-vue-markdown",
+        "vite-svg-loader"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "UnoCSS ecosystem",
+      "matchPackageNames": [
+        "unocss",
+        "@unocss/eslint-config",
+        "unocss-preset-scrollbar"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "Unplugin ecosystem",
+      "matchPackageNames": [
+        "unplugin-auto-import",
+        "unplugin-icons",
+        "unplugin-vue-components"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "Vicons",
+      "matchPackageNames": [
+        "@vicons/material",
+        "@vicons/tabler"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "VueUse",
+      "matchPackageNames": [
+        "@vueuse/core",
+        "@vueuse/head",
+        "@vueuse/router"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "uuid with types",
+      "matchPackageNames": [
+        "uuid",
+        "@types/uuid"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"]
+    },
+    {
+      "groupName": "Type packages with their dependencies",
+      "matchPackagePatterns": ["^@types/"],
+      "matchDepTypes": ["devDependencies"],
+      "excludePackageNames": ["@types/uuid"],
+      "groupSlug": "types",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
- Add grouping for uuid and @types/uuid to prevent type mismatches
- Group Vue ecosystem packages (vue, @vue/*)
- Group Vite ecosystem packages (vite, @vitejs/*, vite-plugin-*)
- Group UnoCSS ecosystem (unocss, presets, configs)
- Group Unplugin packages together
- Group Vicons packages together
- Group VueUse packages together
- Add catch-all for remaining @types packages with automerge

This prevents separate PRs for interdependent packages that can cause
build failures when updated independently.