### PR TITLE
Fix Playwright tests by using pnpm instead of npm for preview command

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
   ...(useWebServer
     && {
       webServer: {
-        command: 'npm run preview',
+        command: 'pnpm run preview',
         url: 'http://localhost:5050',
         reuseExistingServer: !isCI,
       },


### PR DESCRIPTION
The Playwright config was using 'npm run preview' but the project uses pnpm
as its package manager. After the recent fix for npm env warnings (commit
2a3c465), the preview script now uses 'env -u' commands to unset npm config
variables. When invoked via npm instead of pnpm, this causes the Playwright
e2e tests to fail with exit code 1.

This change updates playwright.config.ts to use 'pnpm run preview' instead,
aligning with the project's package manager and ensuring the preview command
runs correctly during e2e tests.

Fixes: https://github.com/TheTechNetwork/it-tools/actions/runs/20185145557