### PR TITLE
fix: remove tabulateAlias option for sql-formatter v15 compatibility

### DIFF
--- a/src/tools/sql-prettify/sql-prettify.vue
+++ b/src/tools/sql-prettify/sql-prettify.vue
@@ -11,7 +11,6 @@ const config = reactive<FormatOptionsWithLanguage>({
   useTabs: false,
   language: 'sql',
   indentStyle: 'standard',
-  tabulateAlias: true,
 });
 
 const rawSQL = ref('select field1,field2,field3 from my_table where my_condition;');


### PR DESCRIPTION
The tabulateAlias option was removed in sql-formatter v15. This change removes the property from the FormatOptions configuration to fix the TypeScript type error.