### PR TITLE
fix: update tsconfig to use @tsconfig/node20

### DIFF
--- a/tsconfig.vite-config.json
+++ b/tsconfig.vite-config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "include": ["vite.config.*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Complete the migration from @tsconfig/node18 to @tsconfig/node20 by updating the extends reference in tsconfig.vite-config.json.

This fixes the build failure caused by PR #470 which updated the package dependency but missed updating the actual tsconfig reference.

Related: #470