### PR TITLE
fix: update tsconfig.vite-config.json to use @tsconfig/node22

### DIFF
--- a/tsconfig.vite-config.json
+++ b/tsconfig.vite-config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["vite.config.*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
This commit fixes the build failures in PR #472 by updating the TypeScript config file to reference the correct package. PR #472 updated package.json from @tsconfig/node20 to @tsconfig/node22, but missed updating the reference in tsconfig.vite-config.json, causing build errors.