### PR TITLE
fix: update tsconfig.vite-config.json to use @tsconfig/node24

### DIFF
--- a/tsconfig.vite-config.json
+++ b/tsconfig.vite-config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "include": ["vite.config.*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Updates the TypeScript configuration to reference @tsconfig/node24 instead of @tsconfig/node22, matching the dependency change in package.json. This fixes build failures caused by the missing @tsconfig/node22 package reference.

Related to PR #476