### PR TITLE
fix(downloadBase64): resolve extension-to-mime-type with lookup, not extension

### DIFF
--- a/src/composable/downloadBase64.test.ts
+++ b/src/composable/downloadBase64.test.ts
@@ -1,7 +1,98 @@
-import { describe, expect, it } from 'vitest';
-import { getMimeTypeFromBase64 } from './downloadBase64';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import {
+  getExtensionFromMimeType,
+  getMimeTypeFromBase64,
+  getMimeTypeFromExtension,
+  useDownloadFileFromBase64,
+} from './downloadBase64';
 
 describe('downloadBase64', () => {
+  describe('getMimeTypeFromExtension', () => {
+    it('returns the mime type for a known extension', () => {
+      expect(getMimeTypeFromExtension('txt')).toBe('text/plain');
+      expect(getMimeTypeFromExtension('png')).toBe('image/png');
+      expect(getMimeTypeFromExtension('json')).toBe('application/json');
+      expect(getMimeTypeFromExtension('pdf')).toBe('application/pdf');
+    });
+
+    it('returns false for an unknown extension', () => {
+      expect(getMimeTypeFromExtension('does-not-exist')).toBe(false);
+    });
+  });
+
+  describe('getExtensionFromMimeType', () => {
+    it('returns the default extension for a known mime type', () => {
+      expect(getExtensionFromMimeType('text/plain')).toBe('txt');
+      expect(getExtensionFromMimeType('image/png')).toBe('png');
+      expect(getExtensionFromMimeType('application/json')).toBe('json');
+    });
+
+    it('returns false for an unknown mime type', () => {
+      expect(getExtensionFromMimeType('application/does-not-exist')).toBe(false);
+    });
+  });
+
+  describe('useDownloadFileFromBase64', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function captureDownloadedAnchor() {
+      const anchor = document.createElement('a');
+      anchor.click = vi.fn();
+      vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+      return anchor;
+    }
+
+    it('builds a data URI with the mime type inferred from the extension when the source has none', () => {
+      const anchor = captureDownloadedAnchor();
+
+      const { download } = useDownloadFileFromBase64({ source: ref('aGVsbG8='), extension: 'txt' });
+      download();
+
+      expect(anchor.href).toBe('data:text/plain;base64,aGVsbG8=');
+      expect(anchor.download).toBe('file.txt');
+    });
+
+    it('falls back to application/octet-stream for an unknown extension', () => {
+      const anchor = captureDownloadedAnchor();
+
+      const { download } = useDownloadFileFromBase64({ source: ref('aGVsbG8='), extension: 'does-not-exist' });
+      download();
+
+      expect(anchor.href).toBe('data:application/octet-stream;base64,aGVsbG8=');
+    });
+
+    it('prefers an explicit fileMimeType over the extension lookup', () => {
+      const anchor = captureDownloadedAnchor();
+
+      const { download } = useDownloadFileFromBase64({
+        source: ref('aGVsbG8='),
+        extension: 'txt',
+        fileMimeType: 'application/custom',
+      });
+      download();
+
+      expect(anchor.href).toBe('data:application/custom;base64,aGVsbG8=');
+    });
+
+    it('keeps the existing data URI when the source already has one', () => {
+      const anchor = captureDownloadedAnchor();
+
+      const { download } = useDownloadFileFromBase64({ source: ref('data:image/png;base64,iVBORw0KGgo=') });
+      download();
+
+      expect(anchor.href).toBe('data:image/png;base64,iVBORw0KGgo=');
+    });
+
+    it('throws when the base64 source is empty', () => {
+      const { download } = useDownloadFileFromBase64({ source: ref('') });
+
+      expect(() => download()).toThrow('Base64 string is empty');
+    });
+  });
+
   describe('getMimeTypeFromBase64', () => {
     it('when the base64 string has a data URI, it returns the mime type', () => {
       expect(getMimeTypeFromBase64({ base64String: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA' })).to.deep.equal({ mimeType: 'image/png' });

--- a/src/composable/downloadBase64.ts
+++ b/src/composable/downloadBase64.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue';
 import _ from 'lodash';
-import { extension as getExtensionFromMimeType, extension as getMimeTypeFromExtension } from 'mime-types';
+import { extension as getExtensionFromMimeType, lookup as getMimeTypeFromExtension } from 'mime-types';
 
 export {
   getExtensionFromMimeType,
@@ -59,7 +59,7 @@ function downloadFromBase64({ sourceValue, filename, extension, fileMimeType }:
   const { mimeType } = getMimeTypeFromBase64({ base64String: sourceValue });
   let base64String = sourceValue;
   if (!mimeType) {
-    const targetMimeType = fileMimeType ?? getMimeTypeFromExtension(defaultExtension);
+    const targetMimeType = fileMimeType ?? (getMimeTypeFromExtension(defaultExtension) || 'application/octet-stream');
     base64String = `data:${targetMimeType};base64,${sourceValue}`;
   }
 


### PR DESCRIPTION
### Description

Fixes a real bug surfaced while writing test coverage in #703.

In `src/composable/downloadBase64.ts`, both mime helpers were aliased to the **same** mime-types function:

```ts
import { extension as getExtensionFromMimeType, extension as getMimeTypeFromExtension } from 'mime-types';
```

`mime-types`' `extension()` maps a **mime type → file extension**, so `getMimeTypeFromExtension('txt')` returned `false` for every real extension. The only caller is the download path: when a base64 source has no data URI, the code builds one from the extension —

```ts
const targetMimeType = fileMimeType ?? getMimeTypeFromExtension(defaultExtension); // -> false
base64String = `data:${targetMimeType};base64,${sourceValue}`;                      // -> "data:false;base64,..."
```

So downloads of raw (non-data-URI) base64 produced a malformed `data:false;base64,...` URL.

### Fix

- Alias `getMimeTypeFromExtension` to mime-types' **`lookup`** (extension → mime type), so `'txt' → 'text/plain'`, `'png' → 'image/png'`, etc.
- Fall back to `application/octet-stream` when the extension is unknown (`lookup` returns `false`), so the data URI is always valid rather than `data:false;...`.

### Tests

Added regression tests to `downloadBase64.test.ts` (which previously only covered `getMimeTypeFromBase64`):
- `getMimeTypeFromExtension` / `getExtensionFromMimeType` direct assertions
- End-to-end `useDownloadFileFromBase64` tests that spy on the created `<a>` and assert the resulting `href` data URI carries the correct mime type, including the unknown-extension fallback, explicit `fileMimeType` precedence, the pass-through-when-already-a-data-URI path, and the empty-source throw.

Confirmed these fail on the pre-fix code (`expected false to be 'text/plain'`) and pass after.

Verified locally: `pnpm test` 736/736 ✅ · `pnpm lint` ✅ · `pnpm typecheck` 0 errors ✅

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Submit the PR against the default branch (`main`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb)_