### PR TITLE
ci: single-source node version from .nvmrc, expand lint scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  PRIMARY_NODE_VERSION: '24.x'
-
 jobs:
   # Lint, typecheck and unit tests (with coverage) - run once on the primary
   # Node version since their results are Node-version independent.
@@ -53,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -128,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -170,7 +167,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Get Playwright version
@@ -249,7 +246,7 @@ jobs:
           fi
 
   # Node compatibility: build + unit tests across other supported Node
-  # versions. The primary version (24.x) is already covered above. Runs on
+  # versions. The primary version (from .nvmrc) is already covered above. Runs on
   # pushes to main and manual dispatch, and gates PRs only when they touch
   # dependencies, build tooling or workflows - the only changes that can
   # realistically break other Node versions.

--- a/.github/workflows/docker-nightly-release.yml
+++ b/.github/workflows/docker-nightly-release.yml
@@ -42,7 +42,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: 24.18.0
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: 24.18.0
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -117,7 +117,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: 24.18.0
+          node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies (for changelog script)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,13 @@
-import antfu from '@antfu/eslint-config'
-import { FlatCompat } from '@eslint/eslintrc'
-import unocss from '@unocss/eslint-config/flat'
+import antfu from '@antfu/eslint-config';
+import { FlatCompat } from '@eslint/eslintrc';
+import unocss from '@unocss/eslint-config/flat';
 
-const compat = new FlatCompat()
+const compat = new FlatCompat();
 
 export default antfu(
   {
+    // Generated declaration files are not hand-authored source.
+    ignores: ['**/*.d.ts'],
     vue: true,
     typescript: true,
     jsonc: true,
@@ -56,4 +58,13 @@ export default antfu(
       'vue/no-empty-component-block': ['error'],
     },
   },
-)
+
+  // Test setup polyfills a Buffer global; the rule's suggested fix
+  // (require('buffer')) conflicts with the project's no-require-imports rule.
+  {
+    files: ['vitest.setup.ts'],
+    rules: {
+      'node/prefer-global/buffer': 'off',
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:e2e:dev": "BASE_URL=http://localhost:5173 NO_WEB_SERVER=true playwright test",
     "coverage": "vitest run --coverage --environment jsdom",
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
-    "lint": "eslint src",
+    "lint": "eslint src scripts *.ts *.mjs --no-warn-ignored",
     "script:create:tool": "node scripts/create-tool.mjs",
     "script:create:ui": "hygen generator ui-component",
     "release": "node ./scripts/release.mjs"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;

--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -1,29 +1,30 @@
-import { mkdir, readFile, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 const currentDirname = dirname(fileURLToPath(import.meta.url));
 
 const toolsDir = join(currentDirname, '..', 'src', 'tools');
-// eslint-disable-next-line no-undef
+
 const toolName = process.argv[2];
 
 if (!toolName) {
   throw new Error('Please specify a toolname.');
 }
 
-const toolNameCamelCase = toolName.replace(/-./g, (x) => x[1].toUpperCase());
+const toolNameCamelCase = toolName.replace(/-./g, x => x[1].toUpperCase());
 const toolNameTitleCase = toolName[0].toUpperCase() + toolName.slice(1).replace(/-/g, ' ');
 const toolDir = join(toolsDir, toolName);
 
 await mkdir(toolDir);
 console.log(`Directory created: ${toolDir}`);
 
-const createToolFile = async (name, content) => {
+async function createToolFile(name, content) {
   const filePath = join(toolDir, name);
   await writeFile(filePath, content.trim());
   console.log(`File created: ${filePath}`);
-};
+}
 
 createToolFile(
   `${toolName}.vue`,
@@ -53,7 +54,7 @@ export const tool = defineTool({
   name: '${toolNameTitleCase}',
   path: '/${toolName}',
   description: '',
-  keywords: ['${toolName.split('-').join("', '")}'],
+  keywords: ['${toolName.split('-').join('\', \'')}'],
   component: () => import('./${toolName}.vue'),
   icon: ArrowsShuffle,
   createdAt: new Date('${new Date().toISOString().split('T')[0]}'),
@@ -97,7 +98,7 @@ test.describe('Tool - ${toolNameTitleCase}', () => {
 );
 
 const toolsIndex = join(toolsDir, 'index.ts');
-const indexContent = await readFile(toolsIndex, { encoding: 'utf-8' }).then((r) => r.split('\n'));
+const indexContent = await readFile(toolsIndex, { encoding: 'utf-8' }).then(r => r.split('\n'));
 
 indexContent.splice(3, 0, `import { tool as ${toolNameCamelCase} } from './${toolName}';`);
 writeFile(toolsIndex, indexContent.join('\n'));

--- a/scripts/getLatestChangelog.mjs
+++ b/scripts/getLatestChangelog.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 
 const changelogContent = await readFile('./CHANGELOG.md', 'utf-8');
 const [, lastChangelog] = changelogContent.split(/^## .*$/gm);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,7 +1,8 @@
-import { $, argv } from 'zx';
+import process from 'node:process';
 import { consola } from 'consola';
-import { rawCommitsToMarkdown } from './shared/commits.mjs';
+import { $, argv } from 'zx';
 import { addToChangelog } from './shared/changelog.mjs';
+import { rawCommitsToMarkdown } from './shared/commits.mjs';
 
 $.verbose = false;
 
@@ -50,7 +51,8 @@ try {
   consola.info('Creating version and tag');
   await $`npm version ${version} -m "chore(version): release ${version}"`;
   consola.info('Npm version released with tag');
-} catch (error) {
+}
+catch (error) {
   consola.error(error);
   consola.info('Aborting');
   process.exit(1);

--- a/scripts/shared/changelog.mjs
+++ b/scripts/shared/changelog.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 export { addToChangelog };
 

--- a/scripts/shared/commits.mjs
+++ b/scripts/shared/commits.mjs
@@ -17,13 +17,14 @@ const commitScopesToHumanReadable = {
 
 const commitTypesOrder = ['feat', 'fix', 'perf', 'refactor', 'test', 'build', 'ci', 'chore', 'other'];
 
-const getCommitTypeSortIndex = (type) =>
-  commitTypesOrder.includes(type) ? commitTypesOrder.indexOf(type) : commitTypesOrder.length;
+function getCommitTypeSortIndex(type) {
+  return commitTypesOrder.includes(type) ? commitTypesOrder.indexOf(type) : commitTypesOrder.length;
+}
 
 function parseCommitLine(commit) {
   const [sha, ...splittedRawMessage] = commit.trim().split(' ');
   const rawMessage = splittedRawMessage.join(' ');
-  const { type, scope, subject } = /^(?<type>.*?)(\((?<scope>.*)\))?: ?(?<subject>.+)$/.exec(rawMessage)?.groups ?? {};
+  const { type, scope, subject } = /^(?<type>[^(:]*)(?:\((?<scope>[^)]*)\))?: ?(?<subject>.+)$/.exec(rawMessage)?.groups ?? {};
 
   return {
     sha: sha.slice(0, 7),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
-import { URL, fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { fileURLToPath, URL } from 'node:url';
 
 import VueI18n from '@intlify/unplugin-vue-i18n/vite';
 import vue from '@vitejs/plugin-vue';
@@ -10,9 +11,9 @@ import IconsResolver from 'unplugin-icons/resolver';
 import Icons from 'unplugin-icons/vite';
 import { NaiveUiResolver } from 'unplugin-vue-components/resolvers';
 import Components from 'unplugin-vue-components/vite';
+import markdown from 'unplugin-vue-markdown/vite';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
-import markdown from 'unplugin-vue-markdown/vite';
 import svgLoader from 'vite-svg-loader';
 import { configDefaults } from 'vitest/config';
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,11 +1,11 @@
 // Vitest setup file to initialize test environment globals
+import { Buffer as NodeBuffer } from 'node:buffer';
 
-// jsdom should already have atob/btoa, but ensure they're properly configured
-if (typeof window !== 'undefined' && typeof global !== 'undefined') {
-  // Ensure Buffer is available if needed
-  if (typeof Buffer === 'undefined') {
-    (global as any).Buffer = require('buffer').Buffer;
-  }
+// jsdom should already have atob/btoa, but ensure a Buffer global is available.
+// Assign onto globalThis through a typed alias so the polyfill is applied.
+const globalScope = globalThis as unknown as { Buffer?: unknown };
+if (typeof window !== 'undefined' && globalScope.Buffer === undefined) {
+  globalScope.Buffer = NodeBuffer;
 }
 
 // Node 25+ defines experimental localStorage/sessionStorage global accessors


### PR DESCRIPTION
### Description

Two tooling improvements.

**1. Single-source the Node version from `.nvmrc`**

The primary Node version was specified in several places (`ci.yml`'s `PRIMARY_NODE_VERSION: 24.x`, plus hardcoded `24.18.0` in `releases.yml` and `docker-nightly-release.yml`). Every `setup-node` step now uses `node-version-file: .nvmrc`, so `.nvmrc` is the single source of truth — bumping Node is a one-line change. The `node-compat` matrix keeps its explicit version list (`22.x`, `25.x`, `26.x`) since it deliberately tests *other* versions.

**2. Expand ESLint scope beyond `src/`**

`lint` was `eslint src`, so `scripts/` and the root build-config files (`vite.config.ts`, `playwright.config.ts`, `vitest.setup.ts`, `eslint.config.mjs`, etc.) were never linted. The script is now `eslint src scripts *.ts *.mjs --no-warn-ignored`, with generated `*.d.ts` files ignored via a config rule. I scoped it to JS/TS code deliberately — running `eslint .` would also try to reformat every locale YAML and JSON config, which isn't the goal here.

Fixes for everything the wider scope surfaced (all style-level or semantics-preserving):
- `node:` protocol import prefixes; explicit `import process` / `Buffer` for Node globals; import ordering; quote/brace style; one arrow→`function` conversion.
- Tightened the conventional-commit parser regex in `scripts/shared/commits.mjs` to remove a super-linear-backtracking ambiguity — verified it parses the same commit shapes (`feat(scope): subject`, `fix: bug`, subjects containing `:`, etc.).
- `vitest.setup.ts`'s Buffer polyfill can't satisfy `node/prefer-global/buffer` and `no-require-imports` at the same time (the former's fix is `require('buffer')`, which the latter forbids), so that one rule is disabled for just that file with a comment explaining why.

### Additional context

Verified locally, all green:
- `pnpm lint` (expanded scope) — exit 0
- `pnpm typecheck` — exit 0
- `pnpm test` — 736 tests pass (exercises the rewritten `vitest.setup.ts`)
- `pnpm build` — succeeds (exercises `vite.config.ts`)
- `actionlint` (+shellcheck) — clean on all workflows

No `src/` files changed and no runtime behaviour changes — this is tooling/config plus lint-driven cleanup of build scripts.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — tooling/config change; validated with lint, typecheck, the full unit suite, a build, and actionlint.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_