### PR TITLE
test: scope unit coverage to the logic layer, add an auto-ratcheting floor

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -139,7 +139,11 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov', 'json-summary'],
-      include: ['src/**/*.ts', 'src/**/*.vue'],
+      // Unit coverage tracks the logic layer (services, composables, utils).
+      // Vue SFCs are exercised by the Playwright e2e suite rather than unit
+      // tests, so including them would drown this metric in ~0%-covered UI and
+      // make it meaningless. They stay out here.
+      include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.test.ts',
         'src/**/*.e2e.spec.ts',
@@ -149,6 +153,15 @@ export default defineConfig({
         'src/main.ts',
         'src/plugins/**',
       ],
+      // No-regression floor for the logic layer (currently ~62% lines / 73%
+      // branches). Fails CI if coverage drops below this; ratchet upward as
+      // more services gain tests.
+      thresholds: {
+        lines: 58,
+        statements: 58,
+        functions: 58,
+        branches: 58,
+      },
     },
   },
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -153,14 +153,17 @@ export default defineConfig({
         'src/main.ts',
         'src/plugins/**',
       ],
-      // No-regression floor for the logic layer (currently ~62% lines / 73%
-      // branches). Fails CI if coverage drops below this; ratchet upward as
-      // more services gain tests.
+      // No-regression floor for the logic layer. Fails CI if coverage drops
+      // below these values. autoUpdate ratchets them upward automatically: when
+      // a local `pnpm coverage` run measures higher coverage, Vitest rewrites
+      // these numbers to the new level (it never lowers them), so improvements
+      // get locked in as the new floor. Commit the bumped values.
       thresholds: {
-        lines: 58,
-        statements: 58,
-        functions: 58,
-        branches: 58,
+        autoUpdate: true,
+        lines: 61.62,
+        statements: 62.31,
+        functions: 63.26,
+        branches: 72.56,
       },
     },
   },


### PR DESCRIPTION
### Description

Makes the unit-coverage metric meaningful and adds a self-ratcheting no-regression floor.

**Problem.** CI reported ~22% coverage, but that number was misleading. `.vue` SFCs were in the coverage `include`, and they're exercised by the Playwright **e2e** suite, not unit tests. The breakdown:

| | lines % | covered/total |
|---|---:|---:|
| `.ts` (logic) | **61.6%** | 713/1157 |
| `.vue` (UI) | **1.1%** | 23/2156 |
| **Total (old CI number)** | **22.2%** | 736/3313 |

2,156 of 3,313 lines (65% of the denominator) were `.vue` sitting at ~1%, dragging the whole number down. The logic layer itself is well-tested — `utils` 93%, `composables` 86%, services 57%.

**Change.**
1. **Exclude `src/**/*.vue` from unit coverage** (`include: ['src/**/*.ts']`). The metric now reflects the logic layer — the thing unit tests are actually responsible for. UI stays owned by the e2e suite.
2. **Add a no-regression threshold**, pinned to current logic-layer coverage (lines 61.62, statements 62.31, functions 63.26, branches 72.56). `pnpm coverage` (run in the CI `checks` job) fails if any metric drops below the floor.
3. **Auto-ratchet via `thresholds.autoUpdate`.** When a local `pnpm coverage` run measures *higher* coverage, Vitest rewrites these numbers upward automatically (never downward). Commit the bumped values and the floor has permanently moved up. So the floor climbs on its own as services gain tests, and can never silently slip back.

**Behaviour note:** because the floor now tracks current coverage exactly (rather than a slack 58% buffer), a change that *drops* coverage — e.g. adding new untested logic — will fail CI. That's the intended one-directional ratchet: new logic comes with tests, or the floor is consciously lowered.

### Additional context

Verified locally:
- `pnpm coverage` with the new config → **61.62% lines / 62.31% stmts / 63.26% funcs / 72.56% branches**, exit 0 (meets the floor exactly).
- `autoUpdate` behaves cleanly: it rewrote the initial 58s to the current values on first run, and is idempotent on subsequent runs (no further rewrite, still passes).
- Sanity-checked the gate enforces: forcing a 99% threshold fails with `ERROR: Coverage for lines (61.62%) does not meet global threshold (99%)` and exit 1.

Single-file change (`vite.config.ts`); no source or runtime behaviour changes.

**Not included (deliberately):** raising the blended number by unit-testing `.vue` components or instrumenting Playwright to feed coverage — a much larger, separate effort we can scope later if you want the UI layer measured too.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — coverage-config change; validated by running `pnpm coverage`, confirming the gate passes at current levels, fails when unmet, and auto-ratchets on improvement.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)