### PR TITLE
ci: harden nginx image and verify the real Docker build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,66 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-24.04-${{ matrix.project }}-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
 
+  # Smoke-test the production nginx config (security headers, gzip, immutable
+  # asset caching, SPA fallback) against the built app, using the same base
+  # image the Dockerfile ships. Reuses the dist/ artifact - no image rebuild.
+  nginx-smoke:
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: Validate nginx config
+        run: |
+          docker run --rm \
+            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+            nginx:stable-alpine nginx -t
+
+      - name: Start nginx with the built app
+        run: |
+          docker run -d --name it-tools-nginx -p 8080:80 \
+            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+            -v "$PWD/dist:/usr/share/nginx/html:ro" \
+            nginx:stable-alpine
+          for _ in {1..20}; do
+            if curl -fsS -o /dev/null http://localhost:8080/; then break; fi
+            sleep 0.5
+          done
+
+      - name: Assert hardening (headers, gzip, caching, SPA fallback)
+        run: |
+          set -eu
+          fail() { echo "ASSERT FAILED: $1"; docker logs it-tools-nginx || true; exit 1; }
+
+          shell_headers=$(curl -sS -D - -o /dev/null http://localhost:8080/)
+          grep -qi '^x-content-type-options: nosniff' <<<"$shell_headers" || fail "X-Content-Type-Options"
+          grep -qi '^x-frame-options: SAMEORIGIN' <<<"$shell_headers" || fail "X-Frame-Options"
+          grep -qi '^referrer-policy: strict-origin-when-cross-origin' <<<"$shell_headers" || fail "Referrer-Policy"
+          grep -qi '^permissions-policy:' <<<"$shell_headers" || fail "Permissions-Policy"
+          grep -qi '^cache-control: no-cache' <<<"$shell_headers" || fail "index.html should be no-cache"
+
+          # Largest hashed asset is guaranteed above gzip_min_length.
+          asset=$(find dist/assets -maxdepth 1 -name '*.js' -printf '%s %f\n' | sort -rn | head -1 | cut -d' ' -f2)
+          asset_headers=$(curl -sS -H 'Accept-Encoding: gzip' -D - -o /dev/null "http://localhost:8080/assets/$asset")
+          grep -qi '^content-encoding: gzip' <<<"$asset_headers" || fail "asset should be gzipped"
+          grep -qi 'max-age=31536000' <<<"$asset_headers" || fail "asset should be long-cached"
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/deep/spa/route)
+          [ "$code" = "200" ] || fail "SPA fallback should return 200 (got $code)"
+
+          echo "nginx hardening assertions passed."
+
+      - name: Stop nginx
+        if: always()
+        run: docker rm -f it-tools-nginx || true
+
   # Detect whether a PR touches anything that could affect Node-version
   # compatibility (dependencies, build tooling, workflow definitions).
   # Ordinary tool-code changes cannot break other Node versions if they pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,91 +218,37 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-24.04-${{ matrix.project }}-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
 
-  # Smoke-test the production nginx config (security headers, gzip, immutable
-  # asset caching, SPA fallback) against the built app, using the same base
-  # image the Dockerfile ships. Reuses the dist/ artifact - no image rebuild.
-  nginx-smoke:
-    needs: build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist
-
-      - name: Validate nginx config
-        run: |
-          docker run --rm \
-            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
-            nginx:stable-alpine nginx -t
-
-      - name: Start nginx with the built app
-        run: |
-          docker run -d --name it-tools-nginx -p 8080:80 \
-            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
-            -v "$PWD/dist:/usr/share/nginx/html:ro" \
-            nginx:stable-alpine
-          for _ in {1..20}; do
-            if curl -fsS -o /dev/null http://localhost:8080/; then break; fi
-            sleep 0.5
-          done
-
-      - name: Assert hardening (headers, gzip, caching, SPA fallback)
-        run: |
-          set -eu
-          fail() { echo "ASSERT FAILED: $1"; docker logs it-tools-nginx || true; exit 1; }
-
-          shell_headers=$(curl -sS -D - -o /dev/null http://localhost:8080/)
-          grep -qi '^x-content-type-options: nosniff' <<<"$shell_headers" || fail "X-Content-Type-Options"
-          grep -qi '^x-frame-options: SAMEORIGIN' <<<"$shell_headers" || fail "X-Frame-Options"
-          grep -qi '^referrer-policy: strict-origin-when-cross-origin' <<<"$shell_headers" || fail "Referrer-Policy"
-          grep -qi '^permissions-policy:' <<<"$shell_headers" || fail "Permissions-Policy"
-          grep -qi '^cache-control: no-cache' <<<"$shell_headers" || fail "index.html should be no-cache"
-
-          # Largest hashed asset is guaranteed above gzip_min_length.
-          asset=$(find dist/assets -maxdepth 1 -name '*.js' -printf '%s %f\n' | sort -rn | head -1 | cut -d' ' -f2)
-          asset_headers=$(curl -sS -H 'Accept-Encoding: gzip' -D - -o /dev/null "http://localhost:8080/assets/$asset")
-          grep -qi '^content-encoding: gzip' <<<"$asset_headers" || fail "asset should be gzipped"
-          grep -qi 'max-age=31536000' <<<"$asset_headers" || fail "asset should be long-cached"
-
-          code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/deep/spa/route)
-          [ "$code" = "200" ] || fail "SPA fallback should return 200 (got $code)"
-
-          echo "nginx hardening assertions passed."
-
-      - name: Stop nginx
-        if: always()
-        run: docker rm -f it-tools-nginx || true
-
   # Detect whether a PR touches anything that could affect Node-version
-  # compatibility (dependencies, build tooling, workflow definitions).
-  # Ordinary tool-code changes cannot break other Node versions if they pass
-  # on the primary one, so only toolchain changes need the compat matrix
-  # before merge.
+  # compatibility (dependencies, build tooling, workflow definitions) or the
+  # Docker image (Dockerfile, nginx.conf, .dockerignore). Ordinary tool-code
+  # changes cannot break either if they pass on the primary Node version, so the
+  # compat matrix and the Docker image test only run when their inputs change.
   toolchain-changes:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Check for Node-toolchain-sensitive changes
+      - name: Detect toolchain- and docker-sensitive changes
         id: filter
         run: |
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-            | grep -qE '^(package\.json|pnpm-lock\.yaml|\.npmrc|vite\.config\.ts|vitest\.setup\.ts|tsconfig[^/]*\.json|\.github/workflows/)'; then
+          changed_files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          if grep -qE '^(package\.json|pnpm-lock\.yaml|\.npmrc|vite\.config\.ts|vitest\.setup\.ts|tsconfig[^/]*\.json|\.github/workflows/)' <<<"$changed_files"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -qE '^(Dockerfile|\.dockerignore|nginx\.conf|\.github/workflows/ci\.yml)' <<<"$changed_files"; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
           fi
 
   # Node compatibility: build + unit tests across other supported Node
@@ -342,3 +288,78 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Build the real production Docker image and verify it end to end: the
+  # HEALTHCHECK reaches "healthy", and nginx serves with the expected security
+  # headers, gzip, asset caching and SPA fallback. Gated to Docker/nginx changes
+  # (via toolchain-changes) so ordinary PRs skip the image build; always runs on
+  # pushes to main and manual dispatch.
+  docker-image:
+    needs: toolchain-changes
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' || needs.toolchain-changes.outputs.docker == 'true')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build image
+        run: docker build -t it-tools:ci .
+
+      - name: Run container (fast health-check cadence)
+        run: |
+          docker run -d --name it-tools-ci -p 8080:80 \
+            --health-start-period=2s --health-interval=2s \
+            --health-timeout=3s --health-retries=5 \
+            it-tools:ci
+
+      - name: Wait for HEALTHCHECK to report healthy
+        run: |
+          for _ in {1..30}; do
+            status=$(docker inspect -f '{{.State.Health.Status}}' it-tools-ci)
+            echo "health: $status"
+            if [ "$status" = "healthy" ]; then exit 0; fi
+            if [ "$status" = "unhealthy" ]; then docker logs it-tools-ci; exit 1; fi
+            sleep 2
+          done
+          echo "timed out waiting for healthy"; docker logs it-tools-ci; exit 1
+
+      - name: Assert serving (headers, gzip, caching, SPA fallback)
+        run: |
+          set -eu
+          fail() { echo "ASSERT FAILED: $1"; docker logs it-tools-ci || true; exit 1; }
+
+          shell_headers=$(curl -sS -D - -o /dev/null http://localhost:8080/)
+          grep -qi '^x-content-type-options: nosniff' <<<"$shell_headers" || fail "X-Content-Type-Options"
+          grep -qi '^x-frame-options: SAMEORIGIN' <<<"$shell_headers" || fail "X-Frame-Options"
+          grep -qi '^referrer-policy: strict-origin-when-cross-origin' <<<"$shell_headers" || fail "Referrer-Policy"
+          grep -qi '^permissions-policy:' <<<"$shell_headers" || fail "Permissions-Policy"
+          grep -qi '^cache-control: no-cache' <<<"$shell_headers" || fail "index.html should be no-cache"
+
+          # Asset references come from the served shell; at least one (the entry
+          # JS or the stylesheet) is above gzip_min_length and must be gzipped.
+          assets=$(curl -sS http://localhost:8080/ | grep -oE '/assets/[^"]+\.(js|css)' | sort -u)
+          [ -n "$assets" ] || fail "no /assets references found in index.html"
+
+          gzipped=0
+          while IFS= read -r a; do
+            [ -n "$a" ] || continue
+            if curl -sS -H 'Accept-Encoding: gzip' -D - -o /dev/null "http://localhost:8080$a" \
+              | grep -qi '^content-encoding: gzip'; then gzipped=1; break; fi
+          done <<<"$assets"
+          [ "$gzipped" = 1 ] || fail "no asset was served gzipped"
+
+          first_asset=$(head -1 <<<"$assets")
+          grep -qi 'max-age=31536000' \
+            <<<"$(curl -sS -D - -o /dev/null "http://localhost:8080$first_asset")" \
+            || fail "asset should be long-cached"
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/deep/spa/route)
+          [ "$code" = "200" ] || fail "SPA fallback should return 200 (got $code)"
+
+          echo "docker image serving assertions passed."
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f it-tools-ci || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ WORKDIR /app
 # Enable corepack for pnpm
 RUN corepack enable
 
-# Copy only dependency files first for better layer caching
-COPY package.json pnpm-lock.yaml ./
+# Copy only dependency files first for better layer caching.
+# pnpm-workspace.yaml carries the build-script approvals (allowBuilds) and
+# .npmrc the pnpm settings, both needed for a clean --frozen-lockfile install.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 # Install dependencies (cached if lockfile doesn't change)
 RUN pnpm i --frozen-lockfile

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,42 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Compression. text/html is always compressed; list the other built types.
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/manifest+json
+        application/xml
+        image/svg+xml;
+
+    # Security headers. These are defined only here at the server level; the
+    # location blocks below deliberately avoid `add_header` (they use `expires`,
+    # which does not reset inherited headers) so every response inherits them.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    # Vite emits content-hashed filenames under /assets, so they can be cached
+    # for a year - a new build produces new names.
+    location /assets/ {
+        expires 1y;
+        try_files $uri =404;
+    }
+
+    # The SPA shell must never be cached, so clients always fetch the current
+    # asset hashes.
+    location = /index.html {
+        expires -1;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
### Description

Hardens the Docker self-host's nginx config **and** adds a CI job that builds and verifies the real production image — the serving layer and the `HEALTHCHECK` were previously never exercised in CI (the image only builds at release/nightly).

**`nginx.conf` hardening**
- **gzip** for text/JS/CSS/JSON/SVG (`text/javascript` included for newer nginx builds; `gzip_min_length 1024`).
- **Security headers** — `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()` (matching the hosted-deploy headers from #717). Defined once at the `server` level; the `location` blocks use only `expires` (which doesn't reset inherited headers), so every response gets them without duplication.
- **Caching** — content-hashed `/assets/*` get a 1-year cache; the SPA shell (`index.html`) is `no-cache`.

**How it's tested in CI (new `docker-image` job)**

Builds the **actual `Dockerfile` image**, runs the container, and:
1. waits for the baked-in **`HEALTHCHECK` to report `healthy`** (with a fast health cadence override so it converges in seconds) — this is the first time the healthcheck added in #712 is actually exercised;
2. `curl`s assertions against the real image for everything we hardened: the four security headers, `no-cache` on the shell, `gzip` + `max-age=31536000` on a served asset, and SPA fallback (`/deep/spa/route` → `200`).

This is strictly more faithful than a mounted-config test — it validates the Dockerfile's `COPY` wiring, the pinned nginx base, and the healthcheck, not just the config file. It's **gated** (via a new `docker` output on `toolchain-changes`) to run only when `Dockerfile`/`nginx.conf`/`.dockerignore`/`ci.yml` change, so ordinary PRs skip the image build; it always runs on pushes to `main`.

### Additional context

- I validated the nginx serving assertions locally against a real nginx serving the actual `dist/` — all pass. The image build + healthcheck run on the GitHub runner (this PR trips the Docker gate, so the job self-verifies here).
- `actionlint` (+shellcheck, which this repo gates on) is clean.
- CSP is intentionally still omitted (needs testing against Monaco/workers/eval — separate effort).
- Only the Docker/nginx self-host is affected; Vercel/Netlify/Cloudflare use their own header config (#717).

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(The new `docker-image` CI job is exactly this — it builds the real image, checks HEALTHCHECK health, and asserts the hardened serving behaviour.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)