### PR TITLE
chore: add editorconfig and pr-title lint, cache docker build, refresh CLAUDE.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown uses trailing whitespace for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,8 +304,17 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Build image
-        run: docker build -t it-tools:ci .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          tags: it-tools:ci
+          cache-from: type=gha,scope=docker-image-ci
+          cache-to: type=gha,mode=max,scope=docker-image-ci
 
       - name: Run container (fast health-check cadence)
         run: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,27 @@
+# Validate that pull request titles follow the Conventional Commits format.
+# The release automation builds the changelog from commit/PR titles
+# (scripts/getLatestChangelog.mjs), so a non-conventional title would produce a
+# malformed changelog entry. This keeps that input clean.
+
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ This document provides comprehensive guidance for AI assistants working with the
 - **Primary Language**: TypeScript
 - **Framework**: Vue 3 (Composition API)
 - **Package Manager**: pnpm (v11)
-- **Node Version**: >= 22.18.0
+- **Node Version**: >= 22.18.0 (dev/CI use the version pinned in `.nvmrc`)
 - **License**: GNU GPLv3
 
 ---
@@ -470,7 +470,10 @@ test.describe('Tool - Tool Name', () => {
 ### Testing Best Practices
 
 1. **Separation**: Keep business logic in `.service.ts` files for easy unit testing
-2. **Coverage**: Aim for high coverage on service files
+2. **Coverage**: Unit coverage tracks the logic layer only (`src/**/*.ts` -
+   services, composables, utils); `.vue` files are excluded and covered by e2e.
+   A no-regression threshold in `vite.config.ts` fails CI on a drop and
+   auto-ratchets upward, so new/edited services should ship with tests
 3. **E2E Focus**: Test critical user flows and edge cases
 4. **Test IDs**: Use `data-test-id` attribute for stable selectors
 5. **Locale**: Tests run with `locale: 'en-GB'` and `timezoneId: 'Europe/Paris'`
@@ -691,18 +694,31 @@ Located in `.github/workflows/`:
 
 Runs on: PR and push to main (except markdown files), plus manual dispatch
 
+The primary Node version comes from `.nvmrc` (via `setup-node`'s
+`node-version-file`); it is the single source of truth. All `pnpm install`
+steps use `--frozen-lockfile`.
+
 Jobs:
-1. **checks**: Lint (ESLint with caching), type check (vue-tsc), unit tests
-   with coverage (Vitest + @vitest/coverage-v8). Coverage is added to the job
-   summary and uploaded as an artifact. Runs once on the primary Node version.
+1. **checks**: Lint (ESLint with caching, over `src`, `scripts` and the root
+   config files), type check (vue-tsc), unit tests with coverage (Vitest +
+   @vitest/coverage-v8). Coverage is scoped to the logic layer (`.vue` files
+   are excluded - they are covered by e2e) and enforced by a no-regression
+   threshold that auto-ratchets upward. Coverage is added to the job summary
+   and uploaded as an artifact. Runs once on the primary Node version.
 2. **build**: Production build, uploads `dist/` as an artifact.
 3. **e2e**: Playwright tests reusing the `dist/` artifact from **build**.
    PRs run Chromium only (3 shards); pushes to main run the full
    Chromium + Firefox + WebKit matrix.
-4. **node-compat**: Build + unit tests across other supported Node versions
-   (22/25/26). Gates PRs only when they touch dependencies, build tooling or
-   workflows (detected by the **toolchain-changes** job); always runs on
-   pushes to main and manual dispatch. Ordinary tool-code PRs skip it.
+4. **node-compat**: Build + unit tests across the other supported Node versions
+   (22/25/26; the primary version from `.nvmrc` is already covered above).
+   Gates PRs only when they touch dependencies, build tooling or workflows
+   (detected by the **toolchain-changes** job); always runs on pushes to main
+   and manual dispatch. Ordinary tool-code PRs skip it.
+5. **docker-image**: Builds the real production Docker image, waits for its
+   HEALTHCHECK to report healthy, then asserts nginx serves with the expected
+   security headers, gzip, asset caching and SPA fallback. Gated to
+   Docker/nginx changes (also via **toolchain-changes**); always runs on pushes
+   to main.
 
 **Caches**:
 - Vite build cache
@@ -710,14 +726,32 @@ Jobs:
 - Vitest cache
 - TypeScript build info
 - Playwright browsers (per browser project)
+- Docker layer cache (`type=gha`) for the docker-image job
 
-#### 2. **releases.yml** - Release Automation
+#### 2. **actionlint.yml** - Workflow Linting
+
+Lints the workflow files (syntax, expressions, shellcheck on `run:` steps) when
+any `.github/workflows/**` file changes.
+
+#### 3. **pr-title.yml** - PR Title Validation
+
+Checks that pull request titles follow Conventional Commits, keeping the
+changelog input clean.
+
+#### 4. **stale.yml** - Stale Issue Management
+
+Marks and closes inactive issues on a schedule (`actions/stale`).
+
+#### 5. **releases.yml** - Release Automation
 
 Automated releases and changelog generation.
 
-#### 3. **docker-nightly-release.yml** - Docker Publishing
+#### 6. **docker-nightly-release.yml** - Docker Publishing
 
 Builds and publishes Docker images.
+
+> Static analysis (SAST) runs via GitHub code-scanning **default setup**
+> (configured in repo settings), not a workflow file in this repo.
 
 ### Concurrency
 
@@ -849,7 +883,11 @@ const value = useVModel(props, 'value', emit);
 - **No sensitive operations**: All tools run client-side
 - **Input sanitization**: Validate and sanitize user input
 - **XSS prevention**: Use DOMPurify for HTML sanitization
-- **CSP**: Content Security Policy configured
+- **Response headers**: The Vercel/Netlify deploy configs and the Docker
+  nginx image set `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`
+  and a `Permissions-Policy`. A Content-Security-Policy is **not** configured -
+  a strict CSP still needs validating against Monaco, web workers and any
+  `eval`/wasm the tools use.
 
 ### Performance
 


### PR DESCRIPTION
### Description

Four small, independent improvements.

1. **`.editorconfig`** — utf-8, 2-space indent, LF, final newline, trim trailing whitespace (markdown keeps trailing whitespace for hard breaks; YAML pinned to 2-space). Gives consistent editing across editors that don't read the ESLint config.

2. **`pr-title.yml`** — a workflow that validates PR titles follow **Conventional Commits** (`amannn/action-semantic-pull-request`, SHA-pinned). The release automation builds the changelog by parsing commit/PR titles (`scripts/getLatestChangelog.mjs`), so a non-conventional title would produce a malformed changelog entry — this keeps that input clean. Uses `pull_request` (not `pull_request_target`) with a read-only token, so it's safe for fork PRs.

3. **Cache the `docker-image` build** — switched the gated `docker-image` job from a plain `docker build` to buildx + `docker/build-push-action` with `cache-from/to: type=gha` (scoped), matching what the release/nightly builds already do. Repeated runs on Docker/nginx PRs reuse layers instead of rebuilding from scratch. `load: true` keeps the image available for the container run.

4. **Refresh `CLAUDE.md`** — the guide had drifted from reality:
   - Corrected the false *"CSP: Content Security Policy configured"* claim — the security **headers** are set (Vercel/Netlify + nginx), but a CSP is deliberately **not** configured (needs validating against Monaco/workers/eval).
   - Updated the CI/testing docs for changes made across this session: expanded lint scope (`src scripts *.ts *.mjs`), logic-layer coverage floor + auto-ratchet, `.nvmrc` as the single Node-version source, the new `docker-image` job, and the `actionlint` / `pr-title` / `stale` workflows plus the note that CodeQL runs via GitHub default setup.

### Additional context

- `actionlint` (+shellcheck) is clean on all workflows including the new `pr-title.yml`.
- No source or runtime code changes.
- Note: this PR's own title is conventional, so it satisfies the new `pr-title` check it adds.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — config/docs/CI change; validated with actionlint and YAML parsing.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_