### PR TITLE
perf(mac-address-lookup): fetch OUI database as a JSON asset

### DIFF
--- a/src/tools/mac-address-lookup/mac-address-lookup.service.test.ts
+++ b/src/tools/mac-address-lookup/mac-address-lookup.service.test.ts
@@ -1,5 +1,9 @@
+import type { OuiData } from './mac-address-lookup.service';
+import db from 'oui-data';
 import { describe, expect, it } from 'vitest';
 import { getVendorValue, lookupMacAddressVendor } from './mac-address-lookup.service';
+
+const ouiData = db as OuiData;
 
 describe('mac-address-lookup', () => {
   describe('getVendorValue', () => {
@@ -28,23 +32,23 @@ describe('mac-address-lookup', () => {
 
   describe('lookupMacAddressVendor', () => {
     it('finds the vendor of a known OUI', () => {
-      expect(lookupMacAddressVendor('20:37:06:12:34:56')).toContain('Cisco Systems');
-      expect(lookupMacAddressVendor('00:00:0C:11:22:33')).toContain('Cisco Systems');
-      expect(lookupMacAddressVendor('00:00:00:00:00:00')).toContain('XEROX CORPORATION');
+      expect(lookupMacAddressVendor(ouiData, '20:37:06:12:34:56')).toContain('Cisco Systems');
+      expect(lookupMacAddressVendor(ouiData, '00:00:0C:11:22:33')).toContain('Cisco Systems');
+      expect(lookupMacAddressVendor(ouiData, '00:00:00:00:00:00')).toContain('XEROX CORPORATION');
     });
 
     it('is case and separator insensitive', () => {
-      expect(lookupMacAddressVendor('20-37-06-ab-cd-ef')).toContain('Cisco Systems');
-      expect(lookupMacAddressVendor('0000.0c11.2233')).toContain('Cisco Systems');
+      expect(lookupMacAddressVendor(ouiData, '20-37-06-ab-cd-ef')).toContain('Cisco Systems');
+      expect(lookupMacAddressVendor(ouiData, '0000.0c11.2233')).toContain('Cisco Systems');
     });
 
     it('returns undefined for an unknown OUI', () => {
-      expect(lookupMacAddressVendor('FF:FF:FF:FF:FF:FF')).toBeUndefined();
+      expect(lookupMacAddressVendor(ouiData, 'FF:FF:FF:FF:FF:FF')).toBeUndefined();
     });
 
     it('returns undefined for empty or invalid input', () => {
-      expect(lookupMacAddressVendor('')).toBeUndefined();
-      expect(lookupMacAddressVendor('not a mac address')).toBeUndefined();
+      expect(lookupMacAddressVendor(ouiData, '')).toBeUndefined();
+      expect(lookupMacAddressVendor(ouiData, 'not a mac address')).toBeUndefined();
     });
   });
 });

--- a/src/tools/mac-address-lookup/mac-address-lookup.service.test.ts
+++ b/src/tools/mac-address-lookup/mac-address-lookup.service.test.ts
@@ -1,7 +1,7 @@
 import type { OuiData } from './mac-address-lookup.service';
 import db from 'oui-data';
-import { describe, expect, it } from 'vitest';
-import { getVendorValue, lookupMacAddressVendor } from './mac-address-lookup.service';
+import { describe, expect, it, vi } from 'vitest';
+import { getVendorValue, loadOuiData, lookupMacAddressVendor } from './mac-address-lookup.service';
 
 const ouiData = db as OuiData;
 
@@ -49,6 +49,23 @@ describe('mac-address-lookup', () => {
     it('returns undefined for empty or invalid input', () => {
       expect(lookupMacAddressVendor(ouiData, '')).toBeUndefined();
       expect(lookupMacAddressVendor(ouiData, 'not a mac address')).toBeUndefined();
+    });
+  });
+
+  describe('loadOuiData', () => {
+    it('fetches and parses the database once, memoising the result', async () => {
+      const fakeDb: OuiData = { 203706: 'Cisco Systems, Inc' };
+      const fetchMock = vi.fn().mockResolvedValue({ json: () => Promise.resolve(fakeDb) });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const first = await loadOuiData();
+      const second = await loadOuiData();
+
+      expect(first).toBe(fakeDb);
+      expect(second).toBe(first);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      vi.unstubAllGlobals();
     });
   });
 });

--- a/src/tools/mac-address-lookup/mac-address-lookup.service.ts
+++ b/src/tools/mac-address-lookup/mac-address-lookup.service.ts
@@ -1,11 +1,25 @@
-import db from 'oui-data';
+// The OUI database is ~4 MB. Import it as a URL asset and fetch it on demand so
+// it ships as a compressed, content-hashed JSON file (parsed once with native
+// JSON.parse) instead of being inlined as a multi-megabyte JS object literal in
+// this tool's chunk.
+import ouiDataUrl from 'oui-data?url';
 
-export { getVendorValue, lookupMacAddressVendor };
+export type OuiData = Record<string, string>;
 
-function getVendorValue(address: string) {
+export { getVendorValue, loadOuiData, lookupMacAddressVendor };
+
+let ouiDataPromise: Promise<OuiData> | undefined;
+
+// Memoised: the database is fetched and parsed at most once per session.
+function loadOuiData(): Promise<OuiData> {
+  ouiDataPromise ??= fetch(ouiDataUrl).then(response => response.json() as Promise<OuiData>);
+  return ouiDataPromise;
+}
+
+function getVendorValue(address: string): string {
   return address.trim().replace(/[.:-]/g, '').toUpperCase().substring(0, 6);
 }
 
-function lookupMacAddressVendor(address: string): string | undefined {
-  return (db as Record<string, string>)[getVendorValue(address)];
+function lookupMacAddressVendor(db: OuiData, address: string): string | undefined {
+  return db[getVendorValue(address)];
 }

--- a/src/tools/mac-address-lookup/mac-address-lookup.vue
+++ b/src/tools/mac-address-lookup/mac-address-lookup.vue
@@ -1,10 +1,20 @@
 <script setup lang="ts">
+import type { OuiData } from './mac-address-lookup.service';
 import { useCopy } from '@/composable/copy';
 import { macAddressValidationRules } from '@/utils/macAddress';
-import { lookupMacAddressVendor } from './mac-address-lookup.service';
+import { loadOuiData, lookupMacAddressVendor } from './mac-address-lookup.service';
 
 const macAddress = ref('20:37:06:12:34:56');
-const details = computed<string | undefined>(() => lookupMacAddressVendor(macAddress.value));
+
+const ouiData = ref<OuiData>();
+loadOuiData().then((db) => {
+  ouiData.value = db;
+});
+
+const loading = computed(() => ouiData.value === undefined);
+const details = computed<string | undefined>(() =>
+  ouiData.value ? lookupMacAddressVendor(ouiData.value, macAddress.value) : undefined,
+);
 
 const { copy } = useCopy({ source: () => details.value ?? '', text: 'Vendor info copied to the clipboard' });
 </script>
@@ -29,7 +39,10 @@ const { copy } = useCopy({ source: () => details.value ?? '', text: 'Vendor info
       Vendor info:
     </div>
     <c-card mb-5>
-      <div v-if="details">
+      <div v-if="loading" italic op-60>
+        Loading vendor database…
+      </div>
+      <div v-else-if="details">
         <div v-for="(detail, index) of details.split('\n')" :key="index">
           {{ detail }}
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -160,9 +160,9 @@ export default defineConfig({
       // get locked in as the new floor. Commit the bumped values.
       thresholds: {
         autoUpdate: true,
-        lines: 61.62,
-        statements: 62.31,
-        functions: 63.26,
+        lines: 61.69,
+        statements: 62.4,
+        functions: 63.41,
         branches: 72.56,
       },
     },


### PR DESCRIPTION
### Description

The MAC-address-lookup tool imported the ~4 MB `oui-data` package directly (`import db from 'oui-data'`), so Vite inlined the entire OUI database as a **JS object literal** — a **3.7 MB** chunk that the browser had to parse as JavaScript when the tool opened.

This imports it as a **URL asset** (`oui-data?url`) and `fetch()` + `JSON.parse`s it on demand instead.

**Measured result (production build):**

| | before | after |
|---|---:|---:|
| tool JS chunk (`mac-address-lookup-*.js`) | ~3.7 MB | **1.7 KB** |
| OUI data | inlined in JS | separate `index-*.json` asset (3.9 MB raw, **~1.2 MB gzipped**, content-hashed → immutably cached + PWA-precached) |

So the database is no longer inlined in JS (verified — the vendor strings are in the `.json` asset, not the chunk), parses via native `JSON.parse` instead of evaluating a giant object literal, and the transfer is the same ~1.2 MB gzipped one-time download.

**Implementation:**
- The service now exposes a memoised `loadOuiData()` (fetched/parsed at most once) plus a **pure** `lookupMacAddressVendor(db, address)`.
- The component loads the DB on mount and shows a brief *"Loading vendor database…"* state, then does synchronous lookups against it — behaviour is otherwise unchanged.
- Unit tests pass the real database directly to the pure lookup, so they still assert real vendors (Cisco, XEROX) without needing `fetch`.

Note: this tool is route-split, so the chunk was never in the initial bundle — but the smaller JS chunk + native JSON parsing is a real open-time win for this tool, and the OUI DB is inherently ~1.2 MB gzipped (that part can't shrink without dropping the registrant-address data the tool displays).

### Additional context

Verified locally: `pnpm typecheck` (0), `pnpm lint` (0), full unit suite **736 passed**, and a production build confirming the chunk/asset split above.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (performance)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(Existing unit tests updated to the pure `lookupMacAddressVendor(db, address)` signature; all pass.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_