### PR TITLE
feat(docker): add rootless and distroless image variants with supply-chain hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 node_modules
-playwright-report
-coverage
 dist
+coverage
+playwright-report
 test-results
+.git
+.github
+.vscode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,17 +306,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # standard: nginx (root) on port 80, has a HEALTHCHECK
+          # every variant listens on 8080; nginx variants have a HEALTHCHECK,
+          # the distroless (no shell) one does not.
           - target: standard
-            port: 80
             healthcheck: true
-          # rootless: nginx-unprivileged on port 8080, has a HEALTHCHECK
           - target: rootless
-            port: 8080
             healthcheck: true
-          # distroless: static-web-server on port 8080, no shell -> no HEALTHCHECK
           - target: distroless
-            port: 8080
             healthcheck: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -336,9 +332,9 @@ jobs:
 
       - name: Run container (${{ matrix.target }})
         run: |
-          # Map host 8080 -> container ${{ matrix.port }}. Health-cadence flags
-          # are harmless on the distroless image (it has no HEALTHCHECK).
-          docker run -d --name it-tools-ci -p 8080:${{ matrix.port }} \
+          # Every variant listens on 8080. Health-cadence flags are harmless on
+          # the distroless image (it has no HEALTHCHECK).
+          docker run -d --name it-tools-ci -p 8080:8080 \
             --health-start-period=2s --health-interval=2s \
             --health-timeout=3s --health-retries=5 \
             it-tools:${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
 
   # Detect whether a PR touches anything that could affect Node-version
   # compatibility (dependencies, build tooling, workflow definitions) or the
-  # Docker image (Dockerfile, nginx.conf, .dockerignore). Ordinary tool-code
+  # Docker image (Dockerfile, docker/, .dockerignore). Ordinary tool-code
   # changes cannot break either if they pass on the primary Node version, so the
   # compat matrix and the Docker image test only run when their inputs change.
   toolchain-changes:
@@ -245,7 +245,7 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
-          if grep -qE '^(Dockerfile|\.dockerignore|nginx\.conf|\.github/workflows/ci\.yml)' <<<"$changed_files"; then
+          if grep -qE '^(Dockerfile|\.dockerignore|docker/|\.github/workflows/ci\.yml)' <<<"$changed_files"; then
             echo "docker=true" >> "$GITHUB_OUTPUT"
           else
             echo "docker=false" >> "$GITHUB_OUTPUT"
@@ -289,11 +289,12 @@ jobs:
       - name: Test
         run: pnpm test
 
-  # Build the real production Docker image and verify it end to end: the
-  # HEALTHCHECK reaches "healthy", and nginx serves with the expected security
-  # headers, gzip, asset caching and SPA fallback. Gated to Docker/nginx changes
-  # (via toolchain-changes) so ordinary PRs skip the image build; always runs on
-  # pushes to main and manual dispatch.
+  # Build each production Docker image variant and verify it end to end: the
+  # container serves, nginx variants reach a healthy HEALTHCHECK, and all three
+  # serve identically (security headers, gzip, asset caching, SPA fallback) -
+  # the shared serving contract that keeps the variants in lockstep. Also scans
+  # each image with Trivy (report-only for now). Gated to Docker changes (via
+  # toolchain-changes) so ordinary PRs skip the image builds; always on main.
   docker-image:
     needs: toolchain-changes
     if: >-
@@ -301,29 +302,57 @@ jobs:
       (github.event_name != 'pull_request' || needs.toolchain-changes.outputs.docker == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # standard: nginx (root) on port 80, has a HEALTHCHECK
+          - target: standard
+            port: 80
+            healthcheck: true
+          # rootless: nginx-unprivileged on port 8080, has a HEALTHCHECK
+          - target: rootless
+            port: 8080
+            healthcheck: true
+          # distroless: static-web-server on port 8080, no shell -> no HEALTHCHECK
+          - target: distroless
+            port: 8080
+            healthcheck: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build image
+      - name: Build image (${{ matrix.target }})
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          target: ${{ matrix.target }}
           load: true
-          tags: it-tools:ci
-          cache-from: type=gha,scope=docker-image-ci
-          cache-to: type=gha,mode=max,scope=docker-image-ci
+          tags: it-tools:${{ matrix.target }}
+          cache-from: type=gha,scope=docker-image-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=docker-image-${{ matrix.target }}
 
-      - name: Run container (fast health-check cadence)
+      - name: Run container (${{ matrix.target }})
         run: |
-          docker run -d --name it-tools-ci -p 8080:80 \
+          # Map host 8080 -> container ${{ matrix.port }}. Health-cadence flags
+          # are harmless on the distroless image (it has no HEALTHCHECK).
+          docker run -d --name it-tools-ci -p 8080:${{ matrix.port }} \
             --health-start-period=2s --health-interval=2s \
             --health-timeout=3s --health-retries=5 \
-            it-tools:ci
+            it-tools:${{ matrix.target }}
 
-      - name: Wait for HEALTHCHECK to report healthy
+      - name: Wait until it serves
+        run: |
+          for _ in {1..30}; do
+            if curl -fsS -o /dev/null http://localhost:8080/; then echo "serving"; exit 0; fi
+            sleep 2
+          done
+          echo "timed out waiting for the server"; docker logs it-tools-ci; exit 1
+
+      - name: Verify HEALTHCHECK reports healthy
+        if: ${{ matrix.healthcheck }}
         run: |
           for _ in {1..30}; do
             status=$(docker inspect -f '{{.State.Health.Status}}' it-tools-ci)
@@ -334,10 +363,10 @@ jobs:
           done
           echo "timed out waiting for healthy"; docker logs it-tools-ci; exit 1
 
-      - name: Assert serving (headers, gzip, caching, SPA fallback)
+      - name: Assert serving contract (headers, gzip, caching, SPA fallback)
         run: |
           set -eu
-          fail() { echo "ASSERT FAILED: $1"; docker logs it-tools-ci || true; exit 1; }
+          fail() { echo "ASSERT FAILED [${{ matrix.target }}]: $1"; docker logs it-tools-ci || true; exit 1; }
 
           shell_headers=$(curl -sS -D - -o /dev/null http://localhost:8080/)
           grep -qi '^x-content-type-options: nosniff' <<<"$shell_headers" || fail "X-Content-Type-Options"
@@ -367,8 +396,17 @@ jobs:
           code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/deep/spa/route)
           [ "$code" = "200" ] || fail "SPA fallback should return 200 (got $code)"
 
-          echo "docker image serving assertions passed."
+          echo "serving contract holds for ${{ matrix.target }}."
 
       - name: Stop container
         if: always()
         run: docker rm -f it-tools-ci || true
+
+      - name: Scan image with Trivy (report-only)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: it-tools:${{ matrix.target }}
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: true
+          format: table
+          exit-code: '0'

--- a/.github/workflows/docker-nightly-release.yml
+++ b/.github/workflows/docker-nightly-release.yml
@@ -95,6 +95,16 @@ jobs:
     timeout-minutes: 30
     needs:
       - ci
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: standard
+            suffix: ''
+          - target: rootless
+            suffix: '-rootless'
+          - target: distroless
+            suffix: '-distroless'
 
     steps:
       - name: Checkout
@@ -119,15 +129,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build and push
+      - name: Build and push (${{ matrix.target }})
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
+          target: ${{ matrix.target }}
           platforms: linux/amd64,linux/arm64
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=nightly-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=nightly-${{ matrix.target }}
           tags: |
-            thetechnetwork/it-tools:nightly
-            ghcr.io/thetechnetwork/it-tools:nightly
+            thetechnetwork/it-tools:nightly${{ matrix.suffix }}
+            ghcr.io/thetechnetwork/it-tools:nightly${{ matrix.suffix }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -55,10 +55,18 @@ jobs:
   docker-release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # standard keeps the unsuffixed tags (:latest, :X.Y.Z) for compat
+          - target: standard
+            suffix: ''
+          - target: rootless
+            suffix: '-rootless'
+          - target: distroless
+            suffix: '-distroless'
     steps:
-      - name: Get release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -81,20 +89,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build and push
+      - name: Docker metadata (${{ matrix.target }})
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          images: |
+            thetechnetwork/it-tools
+            ghcr.io/thetechnetwork/it-tools
+          flavor: |
+            latest=false
+            suffix=${{ matrix.suffix }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+
+      - name: Build and push (${{ matrix.target }})
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
+          target: ${{ matrix.target }}
           platforms: linux/amd64,linux/arm64
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            thetechnetwork/it-tools:latest
-            thetechnetwork/it-tools:${{ env.RELEASE_VERSION }}
-            ghcr.io/thetechnetwork/it-tools:latest
-            ghcr.io/thetechnetwork/it-tools:${{ env.RELEASE_VERSION}}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=release-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=release-${{ matrix.target }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   github-release:
     runs-on: ubuntu-24.04
@@ -147,12 +169,13 @@ jobs:
           body: |
             ## Docker images
 
-            - Docker Hub
-              - `thetechnetwork/it-tools:latest`
-              - `thetechnetwork/it-tools:${{ env.RELEASE_VERSION }}`
-            - GitHub Container Registry
-              - `ghcr.io/thetechnetwork/it-tools:latest`
-              - `ghcr.io/thetechnetwork/it-tools:${{ env.RELEASE_VERSION}}`
+            Three variants are published (Docker Hub `thetechnetwork/it-tools`
+            and GHCR `ghcr.io/thetechnetwork/it-tools`), each as `:latest` and
+            `:${{ env.RELEASE_VERSION }}`:
+
+            - **standard** (default, nginx): `:latest`, `:${{ env.RELEASE_VERSION }}`
+            - **rootless** (nginx-unprivileged, non-root, port 8080): `:latest-rootless`, `:${{ env.RELEASE_VERSION }}-rootless`
+            - **distroless** (static-web-server, non-root, port 8080): `:latest-distroless`, `:${{ env.RELEASE_VERSION }}-distroless`
 
             ## Changelog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,11 +714,13 @@ Jobs:
    Gates PRs only when they touch dependencies, build tooling or workflows
    (detected by the **toolchain-changes** job); always runs on pushes to main
    and manual dispatch. Ordinary tool-code PRs skip it.
-5. **docker-image**: Builds the real production Docker image, waits for its
-   HEALTHCHECK to report healthy, then asserts nginx serves with the expected
-   security headers, gzip, asset caching and SPA fallback. Gated to
-   Docker/nginx changes (also via **toolchain-changes**); always runs on pushes
-   to main.
+5. **docker-image**: Builds each production image variant (standard nginx,
+   rootless nginx-unprivileged, distroless static-web-server; multi-target
+   `Dockerfile`) and verifies them in a matrix: the container serves, nginx
+   variants reach a healthy HEALTHCHECK, and all three serve the same contract
+   (security headers, gzip, asset caching, SPA fallback). Also scans each image
+   with Trivy (report-only). Gated to Docker changes (`Dockerfile`, `docker/`,
+   `.dockerignore`) via **toolchain-changes**; always runs on pushes to main.
 
 **Caches**:
 - Vite build cache
@@ -883,9 +885,11 @@ const value = useVModel(props, 'value', emit);
 - **No sensitive operations**: All tools run client-side
 - **Input sanitization**: Validate and sanitize user input
 - **XSS prevention**: Use DOMPurify for HTML sanitization
-- **Response headers**: The Vercel/Netlify deploy configs and the Docker
-  nginx image set `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`
-  and a `Permissions-Policy`. A Content-Security-Policy is **not** configured -
+- **Response headers**: The Vercel/Netlify deploy configs and all three Docker
+  image variants (nginx config in `docker/nginx.conf.template`, static-web-server
+  config in `docker/sws.toml`) set `X-Content-Type-Options`, `X-Frame-Options`,
+  `Referrer-Policy` and a `Permissions-Policy`. A Content-Security-Policy is
+  **not** configured -
   a strict CSP still needs validating against Monaco, web workers and any
   `eval`/wasm the tools use.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,13 @@ EXPOSE 8080
 CMD ["-w", "/etc/sws.toml"]
 
 # ---------------------------------------------------------------------------
-# standard (default target): stock nginx, runs as root, listens on 80. Kept as
-# the default so existing `docker build .` / `:latest` users are unaffected.
+# standard (default target): stock nginx, runs as root. Listens on 8080 like
+# the other variants so every image uses the same container port.
 # ---------------------------------------------------------------------------
 FROM nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46 AS standard
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
-ENV NGINX_PORT=80
-EXPOSE 80
+ENV NGINX_PORT=8080
+EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD wget -q --spider http://127.0.0.1:80/ || exit 1
+  CMD wget -q --spider http://127.0.0.1:8080/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,67 @@
-# build stage
+# syntax=docker/dockerfile:1
+#
+# Three image variants share one build stage. Build a specific one with
+# `docker build --target <standard|rootless|distroless> .`; a plain
+# `docker build .` produces the standard image (the last stage) for backward
+# compatibility. All three serve the same built app with identical behaviour
+# (gzip, security headers, immutable asset caching, no-cache SPA shell, SPA
+# fallback) - verified by the docker-image CI job.
+
+# ---------------------------------------------------------------------------
+# Shared build stage: install dependencies and build the static app once.
+# ---------------------------------------------------------------------------
 FROM node:lts-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS build-stage
-# Set environment variables for non-interactive npm installs
 ENV NPM_CONFIG_LOGLEVEL=warn
 ENV CI=true
 WORKDIR /app
 
-# Enable corepack for pnpm
 RUN corepack enable
 
 # Copy only dependency files first for better layer caching.
 # pnpm-workspace.yaml carries the build-script approvals (allowBuilds) and
 # .npmrc the pnpm settings, both needed for a clean --frozen-lockfile install.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-
-# Install dependencies (cached if lockfile doesn't change)
 RUN pnpm i --frozen-lockfile
 
-# Copy source code (changes frequently, placed after deps install)
+# Copy source (changes frequently, placed after deps install) and build.
 COPY . .
-
-# Build the application
 RUN pnpm build
 
-# production stage
-FROM nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46 AS production-stage
+# ---------------------------------------------------------------------------
+# rootless: nginx-unprivileged. Runs as non-root (UID 101), listens on 8080
+# (a non-root process cannot bind ports < 1024). Same nginx config as standard,
+# only the templated listen port differs.
+# ---------------------------------------------------------------------------
+FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:44e36330f74d4f3a1d4e222acca9e23b401fb87811a7597024502bb759c4dd49 AS rootless
 COPY --from=build-stage /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-# Probe the served app so orchestrators can detect an unhealthy container.
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+ENV NGINX_PORT=8080
+EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD wget -q --spider http://127.0.0.1/ || exit 1
-CMD ["nginx", "-g", "daemon off;"]
+  CMD wget -q --spider http://127.0.0.1:8080/ || exit 1
+
+# ---------------------------------------------------------------------------
+# distroless: static-web-server on a scratch base. No shell or package manager;
+# runs as non-root and listens on 8080. There is no shell for a Docker
+# HEALTHCHECK - use an orchestrator HTTP readiness/liveness probe against
+# http://<host>:8080/ instead. Serving behaviour matches the nginx variants via
+# docker/sws.toml.
+# ---------------------------------------------------------------------------
+FROM joseluisq/static-web-server:2@sha256:6acea6260b14e08dda986361e42640082fbfaab8d88c327de532bb13a3b22994 AS distroless
+COPY --from=build-stage /app/dist /public
+COPY docker/sws.toml /etc/sws.toml
+USER 65534:65534
+EXPOSE 8080
+CMD ["-w", "/etc/sws.toml"]
+
+# ---------------------------------------------------------------------------
+# standard (default target): stock nginx, runs as root, listens on 80. Kept as
+# the default so existing `docker build .` / `:latest` users are unaffected.
+# ---------------------------------------------------------------------------
+FROM nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46 AS standard
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+ENV NGINX_PORT=80
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://127.0.0.1:80/ || exit 1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,38 @@ docker run -d --name it-tools --restart unless-stopped -p 8080:80 corentinth/it-
 docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corentinth/it-tools:latest
 ```
 
+### Image variants
+
+This fork publishes three image variants to both `thetechnetwork/it-tools`
+(Docker Hub) and `ghcr.io/thetechnetwork/it-tools`, each tagged `:latest` and
+`:<version>`. All three serve the same app identically (gzip, security headers,
+immutable asset caching, SPA fallback):
+
+| Variant | Tag suffix | Base | User | Port |
+| --- | --- | --- | --- | --- |
+| **standard** | *(none)* — `:latest` | `nginx:stable-alpine` | root | 80 |
+| **rootless** | `:latest-rootless` | `nginx-unprivileged` | non-root (101) | 8080 |
+| **distroless** | `:latest-distroless` | `static-web-server` (scratch) | non-root | 8080 |
+
+```sh
+# standard (unchanged)
+docker run -d --name it-tools -p 8080:80 thetechnetwork/it-tools:latest
+
+# rootless / distroless serve on 8080 inside the container
+docker run -d --name it-tools -p 8080:8080 thetechnetwork/it-tools:latest-rootless
+```
+
+The **rootless** and **distroless** variants pair well with a hardened runtime.
+The distroless image has no shell, so use an orchestrator HTTP probe against
+`/` instead of a Docker `HEALTHCHECK`. Example (rootless):
+
+```sh
+docker run -d --name it-tools -p 8080:8080 \
+  --read-only --tmpfs /tmp \
+  --cap-drop ALL --security-opt no-new-privileges \
+  thetechnetwork/it-tools:latest-rootless
+```
+
 **Other solutions:**
 
 - [Cloudron](https://www.cloudron.io/store/tech.ittools.cloudron.html)

--- a/README.md
+++ b/README.md
@@ -18,24 +18,26 @@ You have an idea of a tool? Submit a [feature request](https://github.com/Corent
 
 ## Self host
 
-Self host solutions for your homelab
+Self host solutions for your homelab. Images are published from this fork
+(`thetechnetwork/it-tools`, the actively maintained source) to Docker Hub and
+GitHub packages.
 
-**From docker hub:**
+**From Docker Hub:**
 
 ```sh
-docker run -d --name it-tools --restart unless-stopped -p 8080:80 corentinth/it-tools:latest
+docker run -d --name it-tools --restart unless-stopped -p 8080:8080 thetechnetwork/it-tools:latest
 ```
 
-**From github packages:**
+**From GitHub packages:**
 
 ```sh
-docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corentinth/it-tools:latest
+docker run -d --name it-tools --restart unless-stopped -p 8080:8080 ghcr.io/thetechnetwork/it-tools:latest
 ```
 
 ### Image variants
 
-This fork publishes three image variants to both `thetechnetwork/it-tools`
-(Docker Hub) and `ghcr.io/thetechnetwork/it-tools`, each tagged `:latest` and
+Three image variants are published to both `thetechnetwork/it-tools` (Docker
+Hub) and `ghcr.io/thetechnetwork/it-tools`, each tagged `:latest` and
 `:<version>`. All three **listen on port 8080** and serve the same app
 identically (gzip, security headers, immutable asset caching, SPA fallback):
 
@@ -44,13 +46,6 @@ identically (gzip, security headers, immutable asset caching, SPA fallback):
 | **standard** | *(none)* — `:latest` | `nginx:stable-alpine` | root |
 | **rootless** | `:latest-rootless` | `nginx-unprivileged` | non-root (101) |
 | **distroless** | `:latest-distroless` | `static-web-server` (scratch) | non-root |
-
-```sh
-docker run -d --name it-tools -p 8080:8080 thetechnetwork/it-tools:latest
-```
-
-> **Note:** the container now listens on **8080** (not 80). If you previously
-> ran the standard image with `-p 8080:80`, switch to `-p 8080:8080`.
 
 The **rootless** and **distroless** variants pair well with a hardened runtime.
 The distroless image has no shell, so use an orchestrator HTTP probe against
@@ -62,6 +57,19 @@ docker run -d --name it-tools -p 8080:8080 \
   --cap-drop ALL --security-opt no-new-privileges \
   thetechnetwork/it-tools:latest-rootless
 ```
+
+<details>
+<summary>Upstream images (<code>CorentinTh/it-tools</code>)</summary>
+
+The original upstream project is no longer actively maintained. Its images
+listened on port 80 and are kept here for reference:
+
+```sh
+docker run -d --name it-tools --restart unless-stopped -p 8080:80 corentinth/it-tools:latest
+docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corentinth/it-tools:latest
+```
+
+</details>
 
 **Other solutions:**
 

--- a/README.md
+++ b/README.md
@@ -36,22 +36,21 @@ docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corent
 
 This fork publishes three image variants to both `thetechnetwork/it-tools`
 (Docker Hub) and `ghcr.io/thetechnetwork/it-tools`, each tagged `:latest` and
-`:<version>`. All three serve the same app identically (gzip, security headers,
-immutable asset caching, SPA fallback):
+`:<version>`. All three **listen on port 8080** and serve the same app
+identically (gzip, security headers, immutable asset caching, SPA fallback):
 
-| Variant | Tag suffix | Base | User | Port |
-| --- | --- | --- | --- | --- |
-| **standard** | *(none)* — `:latest` | `nginx:stable-alpine` | root | 80 |
-| **rootless** | `:latest-rootless` | `nginx-unprivileged` | non-root (101) | 8080 |
-| **distroless** | `:latest-distroless` | `static-web-server` (scratch) | non-root | 8080 |
+| Variant | Tag suffix | Base | User |
+| --- | --- | --- | --- |
+| **standard** | *(none)* — `:latest` | `nginx:stable-alpine` | root |
+| **rootless** | `:latest-rootless` | `nginx-unprivileged` | non-root (101) |
+| **distroless** | `:latest-distroless` | `static-web-server` (scratch) | non-root |
 
 ```sh
-# standard (unchanged)
-docker run -d --name it-tools -p 8080:80 thetechnetwork/it-tools:latest
-
-# rootless / distroless serve on 8080 inside the container
-docker run -d --name it-tools -p 8080:8080 thetechnetwork/it-tools:latest-rootless
+docker run -d --name it-tools -p 8080:8080 thetechnetwork/it-tools:latest
 ```
+
+> **Note:** the container now listens on **8080** (not 80). If you previously
+> ran the standard image with `-p 8080:80`, switch to `-p 8080:8080`.
 
 The **rootless** and **distroless** variants pair well with a hardened runtime.
 The distroless image has no shell, so use an orchestrator HTTP probe against

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,5 +1,8 @@
+# Shared by the standard and rootless nginx image variants. The listen port is
+# templated (${NGINX_PORT}) and substituted by the nginx entrypoint's envsubst:
+# 80 for the standard image, 8080 for the rootless (non-root can't bind <1024).
 server {
-    listen 80;
+    listen ${NGINX_PORT};
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;

--- a/docker/sws.toml
+++ b/docker/sws.toml
@@ -1,0 +1,43 @@
+# static-web-server config for the distroless image variant. It reproduces the
+# exact serving contract of the nginx variants (docker/nginx.conf.template):
+# gzip, the four security headers, immutable caching for content-hashed
+# /assets, a non-cacheable SPA shell, and SPA fallback with a 200 status.
+[general]
+host = "0.0.0.0"
+port = 8080
+root = "/public"
+
+# SPA fallback: unknown paths serve index.html with a 200 (client-side routing).
+page-fallback = "/public/index.html"
+
+# On-the-fly gzip/brotli/etc. for text-based types (matches nginx `gzip on`).
+compression = true
+
+# Set cache-control and security headers explicitly below, so disable the
+# built-in defaults (which use different values, e.g. X-Frame-Options: DENY).
+cache-control-headers = false
+security-headers = false
+
+[advanced]
+# Security headers on every response. SWS merges headers from all matching
+# `source` globs, so the more specific /assets and /index.html rules below add
+# their Cache-Control on top of these rather than replacing them.
+[[advanced.headers]]
+source = "**"
+[advanced.headers.headers]
+X-Content-Type-Options = "nosniff"
+X-Frame-Options = "SAMEORIGIN"
+Referrer-Policy = "strict-origin-when-cross-origin"
+Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+
+# Content-hashed assets can be cached for a year.
+[[advanced.headers]]
+source = "/assets/**"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"
+
+# The SPA shell must always be revalidated so new asset hashes are picked up.
+[[advanced.headers]]
+source = "/index.html"
+[advanced.headers.headers]
+Cache-Control = "no-cache"


### PR DESCRIPTION
### Description

Ships **three production image variants** from one multi-target `Dockerfile`, all serving the app **identically** (gzip, the four security headers, immutable `/assets` caching, no-cache SPA shell, SPA fallback) and **all listening on port 8080**. The `docker-image` CI job is the parity guardrail that keeps them in lockstep.

| Variant | Target | Base | User | Tags |
|---|---|---|---|---|
| **standard** | `standard` (default) | `nginx:stable-alpine` | root | `:latest`, `:X.Y.Z` |
| **rootless** | `rootless` | `nginx-unprivileged` | non-root (101) | `:latest-rootless`, `:X.Y.Z-rootless` |
| **distroless** | `distroless` | `static-web-server` (scratch) | non-root | `:latest-distroless`, `:X.Y.Z-distroless` |

> ⚠️ **Port change:** every variant (including the standard image) now listens on **8080**, not 80, to keep all images uniform. Users running the standard image with `-p 8080:80` must switch to **`-p 8080:8080`**. Image tags are unchanged.

**Config parity.** The two nginx variants share one templated config (`docker/nginx.conf.template`, `listen ${NGINX_PORT}` via the nginx entrypoint's envsubst). The distroless variant reproduces the same contract in `docker/sws.toml`. Validated locally against the real `dist/`: SWS **merges** the `**` security headers with the per-path `/assets` and `/index.html` cache-control, and `--page-fallback` returns **200** for SPA routes — full parity.

**CI (`docker-image` → matrix over the 3 targets).** Each variant: build → verify it serves → verify a **healthy HEALTHCHECK** (nginx variants; distroless has no shell, so readiness is polled) → assert the shared serving contract. Plus a **report-only Trivy** scan per image (`HIGH,CRITICAL`, `ignore-unfixed`, `exit-code: 0` — flip to `1` to gate later). Gated to Docker changes; runs all three on `main`.

**Publishing (`releases.yml` + `docker-nightly`).** Each variant is built+pushed with tag suffixes via `docker/metadata-action` (which also injects **OCI image labels**), with **SBOM** (`sbom: true`) and **SLSA provenance** (`provenance: mode=max`). Standard keeps its existing unsuffixed tags.

**Also:** moved `nginx.conf` → `docker/nginx.conf.template`; extended `.dockerignore` (`.git`/`.github`/`.vscode`); documented the variants + a hardened `docker run` (read-only rootfs + tmpfs + `cap-drop ALL` + `no-new-privileges`) in the README; updated CLAUDE.md.

### Testing notes

- **Serving contract validated locally** for both the templated nginx config (local nginx) and the exact `docker/sws.toml` (a locally-built static-web-server) — all assertions pass.
- **All base images pinned by digest** (`nginx-unprivileged@sha256:44e363…`, `static-web-server:2@sha256:6acea6…`, multi-arch amd64+arm64); SWS `ENTRYPOINT`/no-CMD/root confirmed from its image config.
- `actionlint` (+shellcheck) clean on all workflows.
- The **image builds** are verified by this PR's `docker-image` matrix. The `releases.yml`/`docker-nightly` changes only run on tag-push/schedule, so those are validated by actionlint + review here, not this PR's CI.
- **CSP** still intentionally omitted; **Trivy** intentionally report-only for the first landing.

### ⚠️ Reviewer notes
- The distroless image has **no shell**, so no Docker `HEALTHCHECK` — use an orchestrator HTTP probe against `/` (documented in the README).
- SBOM/provenance attestations attach on **push** (release/nightly), not on the CI job's `load: true` image — expected.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other (CI / supply-chain)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(The `docker-image` CI matrix builds and asserts all three variants; the serving contract was also validated locally against real nginx and static-web-server.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)