### PR TITLE
fix(security): set security headers on Cloudflare Pages via _headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,13 @@
-# Cloudflare Pages headers for PWA support
+# Cloudflare Pages headers (also honoured by Netlify). Cloudflare does not read
+# vercel.json / netlify.toml, so the security headers must live here too.
 # See: https://github.com/vite-pwa/vite-plugin-pwa/pull/353
+
+# Security headers on every response (matches vercel.json and netlify.toml).
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 # Root - no cache
 /


### PR DESCRIPTION
### Description

The public-facing site **`tools.thetech.network` is served by Cloudflare Pages**, which does **not** read `vercel.json` or `netlify.toml`. As a result, two of the four security headers were **missing in production**:

| Header | Vercel | Netlify | Cloudflare (prod) |
|---|:--:|:--:|:--:|
| `X-Content-Type-Options` | ✅ | ✅ | ✅ (CF default) |
| `Referrer-Policy` | ✅ | ✅ | ✅ (CF default) |
| **`X-Frame-Options`** | ✅ | ✅ | ❌ **missing** |
| **`Permissions-Policy`** | ✅ | ✅ | ❌ **missing** |

(Verified by `curl -I` against the live deployments.) Without `X-Frame-Options`, production had no clickjacking protection.

**Fix:** `public/_headers` already existed (for PWA cache-control) but set no security headers. This adds a `/*` rule with the same four security headers that `vercel.json` and `netlify.toml` set, so Cloudflare Pages now serves them too. Vite copies `public/_headers` into `dist/` root, where Cloudflare Pages (and Netlify) read it; Cloudflare merges the `/*` rule with the existing per-path cache rules.

### Additional context

- Matches the header set from #717 (nosniff, frame, referrer, permissions).
- No code/build changes; will be verifiable by `curl -I https://tools.thetech.network/` once deployed.
- Note: `#726` (the Docker image variants) merged just before this could be folded in, so this ships as its own small PR.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — static host header config; validated by `curl -I` against the live deployments showing the gap.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_