### PR TITLE
ci(security): sign images with cosign and make Trivy scan blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,10 @@ jobs:
   # container serves, nginx variants reach a healthy HEALTHCHECK, and all three
   # serve identically (security headers, gzip, asset caching, SPA fallback) -
   # the shared serving contract that keeps the variants in lockstep. Also scans
-  # each image with Trivy (report-only for now). Gated to Docker changes (via
-  # toolchain-changes) so ordinary PRs skip the image builds; always on main.
+  # each image with Trivy, which fails the job on a fixable HIGH/CRITICAL
+  # (ignore-unfixed keeps un-actionable base-image CVEs from blocking). Gated to
+  # Docker changes (via toolchain-changes) so ordinary PRs skip the image
+  # builds; always on main.
   docker-image:
     needs: toolchain-changes
     if: >-
@@ -398,11 +400,11 @@ jobs:
         if: always()
         run: docker rm -f it-tools-ci || true
 
-      - name: Scan image with Trivy (report-only)
+      - name: Scan image with Trivy (fails on fixable HIGH/CRITICAL)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: it-tools:${{ matrix.target }}
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           format: table
-          exit-code: '0'
+          exit-code: '1'

--- a/.github/workflows/docker-nightly-release.yml
+++ b/.github/workflows/docker-nightly-release.yml
@@ -95,6 +95,11 @@ jobs:
     timeout-minutes: 30
     needs:
       - ci
+    # id-token: write lets cosign fetch an OIDC token for keyless signing.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +135,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push (${{ matrix.target }})
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -144,3 +150,16 @@ jobs:
           tags: |
             thetechnetwork/it-tools:nightly${{ matrix.suffix }}
             ghcr.io/thetechnetwork/it-tools:nightly${{ matrix.suffix }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign the images (keyless)
+        env:
+          # The manifest digest is identical across both registries, so signing
+          # each registry ref by digest signs the exact artifact that was pushed.
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "thetechnetwork/it-tools@${DIGEST}" \
+            "ghcr.io/thetechnetwork/it-tools@${DIGEST}"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -55,6 +55,11 @@ jobs:
   docker-release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # id-token: write lets cosign fetch an OIDC token for keyless signing.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +109,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and push (${{ matrix.target }})
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -117,6 +123,19 @@ jobs:
           cache-to: type=gha,mode=max,scope=release-${{ matrix.target }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign the images (keyless)
+        env:
+          # The manifest digest is identical across both registries, so signing
+          # each registry ref by digest signs the exact artifact that was pushed.
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "thetechnetwork/it-tools@${DIGEST}" \
+            "ghcr.io/thetechnetwork/it-tools@${DIGEST}"
 
   github-release:
     runs-on: ubuntu-24.04
@@ -176,6 +195,16 @@ jobs:
             - **standard** (default, nginx): `:latest`, `:${{ env.RELEASE_VERSION }}`
             - **rootless** (nginx-unprivileged, non-root, port 8080): `:latest-rootless`, `:${{ env.RELEASE_VERSION }}-rootless`
             - **distroless** (static-web-server, non-root, port 8080): `:latest-distroless`, `:${{ env.RELEASE_VERSION }}-distroless`
+
+            All images are signed with cosign (keyless) and ship SBOM + SLSA
+            provenance attestations. Verify:
+
+            ```sh
+            cosign verify \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/' \
+              thetechnetwork/it-tools:${{ env.RELEASE_VERSION }}
+            ```
 
             ## Changelog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,8 +719,10 @@ Jobs:
    `Dockerfile`) and verifies them in a matrix: the container serves, nginx
    variants reach a healthy HEALTHCHECK, and all three serve the same contract
    (security headers, gzip, asset caching, SPA fallback). Also scans each image
-   with Trivy (report-only). Gated to Docker changes (`Dockerfile`, `docker/`,
-   `.dockerignore`) via **toolchain-changes**; always runs on pushes to main.
+   with Trivy, which **fails the job on a fixable HIGH/CRITICAL**
+   (`ignore-unfixed` keeps un-actionable base-image CVEs from blocking). Gated
+   to Docker changes (`Dockerfile`, `docker/`, `.dockerignore`) via
+   **toolchain-changes**; always runs on pushes to main.
 
 **Caches**:
 - Vite build cache
@@ -746,11 +748,18 @@ Marks and closes inactive issues on a schedule (`actions/stale`).
 
 #### 5. **releases.yml** - Release Automation
 
-Automated releases and changelog generation.
+Tag-triggered (`v*.*.*`): builds the app, publishes all three Docker image
+variants (Docker Hub + GHCR, multi-arch), and drafts a GitHub release with the
+changelog. Each pushed image carries a build SBOM (`sbom: true`) and SLSA
+provenance (`provenance: mode=max`) attestation and is **signed with cosign**
+keyless (Sigstore/OIDC - `id-token: write`, no stored keys). See "Supply chain"
+below for verification.
 
 #### 6. **docker-nightly-release.yml** - Docker Publishing
 
-Builds and publishes Docker images.
+Nightly (and manual) build+publish of the three `:nightly*` image variants, with
+the same SBOM + provenance attestations and keyless cosign signing as the
+release workflow.
 
 > Static analysis (SAST) runs via GitHub code-scanning **default setup**
 > (configured in repo settings), not a workflow file in this repo.
@@ -892,6 +901,15 @@ const value = useVModel(props, 'value', emit);
   **not** configured -
   a strict CSP still needs validating against Monaco, web workers and any
   `eval`/wasm the tools use.
+- **Supply chain**: published images (release + nightly, all variants, both
+  registries) ship a build SBOM and SLSA provenance attestation and are signed
+  with **cosign keyless** (Sigstore/OIDC; identity = the GitHub Actions workflow,
+  recorded in the public transparency log). Verify with `cosign verify
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/'
+  thetechnetwork/it-tools:latest` (see README "Verify image signatures"). CI's
+  Trivy scan of each image variant is a **blocking** gate on fixable
+  HIGH/CRITICAL vulnerabilities.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ docker run -d --name it-tools -p 8080:8080 \
   thetechnetwork/it-tools:latest-rootless
 ```
 
+### Verify image signatures
+
+Every published image (all variants, both registries) is signed with
+[cosign](https://docs.sigstore.dev/) using keyless
+[Sigstore](https://www.sigstore.dev/) signing — no long-lived keys, the
+signer's identity is the GitHub Actions workflow that built it, recorded in the
+public transparency log. Verify before pulling:
+
+```sh
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/' \
+  thetechnetwork/it-tools:latest
+```
+
+Images also ship a build [SBOM](https://docs.docker.com/build/metadata/attestations/sla-sbom/)
+and [SLSA provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance/)
+attestation; inspect them with `docker buildx imagetools inspect thetechnetwork/it-tools:latest`.
+
 <details>
 <summary>Upstream images (<code>CorentinTh/it-tools</code>)</summary>
 


### PR DESCRIPTION
### Description

Supply-chain hardening for the three published Docker image variants, building on the SBOM + SLSA provenance attestations they already carry.

**1. Keyless cosign signing of every published image.** The release (`releases.yml`) and nightly (`docker-nightly-release.yml`) workflows now sign each pushed image — all variants, both Docker Hub and GHCR — with cosign using Sigstore keyless signing (OIDC). There are no long-lived keys: the signer identity is the GitHub Actions workflow itself, recorded in the public Rekor transparency log. Each registry ref is signed by the pushed manifest digest (identical across registries), and the publishing jobs get `id-token: write`. `sigstore/cosign-installer` is pinned by commit SHA per repo convention.

**2. Trivy image scan flipped from report-only to blocking.** The `docker-image` CI job's Trivy scan now fails on a fixable HIGH/CRITICAL (`exit-code: 1`, `ignore-unfixed: true`). Triage of the current baseline shows all three variants are clean, so this stays green today and only bites on future regressions:

| Variant | Base | Trivy |
| --- | --- | --- |
| standard | `nginx:stable-alpine` (alpine 3.24.1) | 0 |
| rootless | `nginx-unprivileged` (alpine 3.24.1) | 0 |
| distroless | `static-web-server` on scratch | no OS/packages to scan |

**3. Verification docs.** README gains a "Verify image signatures" section (`cosign verify` + `docker buildx imagetools inspect`); the drafted release notes include the same `cosign verify` snippet; CLAUDE.md CI/security docs updated.

### Additional context

- Signing is purely additive — nothing about how the images are built or what they serve changes.
- The release/nightly signing steps can only exercise on a real tag push / schedule, so they can't run in this PR's CI; the workflow YAML validates and the `docker-image` job (which does run when Docker files change) exercises the Trivy gate flip.
- `cosign verify` identity regexp is case-insensitive to be robust to org-name casing in the OIDC certificate.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (CI / supply-chain security)

### Before submitting the PR, please make sure you do the following

- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Workflow YAML validated; Trivy-gate change is exercised by the existing `docker-image` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_