### PR TITLE
ci(security): add signed SBOM attestation and a report-only Trivy audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,20 @@ jobs:
         if: always()
         run: docker rm -f it-tools-ci || true
 
+      # Full audit: report-only, includes unfixed CVEs, so the log shows the
+      # complete HIGH/CRITICAL exposure (fixable and not) for visibility. Never
+      # blocks - it is the "what's lurking" view.
+      - name: Trivy full audit (report-only, includes unfixed)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: it-tools:${{ matrix.target }}
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: false
+          format: table
+          exit-code: '0'
+
+      # Gate: fails the job only on a *fixable* HIGH/CRITICAL - something an
+      # image rebuild or base-image bump can actually resolve.
       - name: Scan image with Trivy (fails on fixable HIGH/CRITICAL)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:

--- a/.github/workflows/docker-nightly-release.yml
+++ b/.github/workflows/docker-nightly-release.yml
@@ -163,3 +163,23 @@ jobs:
           cosign sign --yes \
             "thetechnetwork/it-tools@${DIGEST}" \
             "ghcr.io/thetechnetwork/it-tools@${DIGEST}"
+
+      - name: Generate CycloneDX SBOM (${{ matrix.target }})
+        uses: anchore/sbom-action@0b82b0b1a22399a1c542d4d656f70cd903571b5c # v0.21.1
+        with:
+          image: ghcr.io/thetechnetwork/it-tools@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest the SBOM (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          # Signed, transparency-logged CycloneDX attestation on each registry
+          # ref by digest (complements the buildkit sbom: true attestation).
+          for ref in "thetechnetwork/it-tools" "ghcr.io/thetechnetwork/it-tools"; do
+            cosign attest --yes --type cyclonedx \
+              --predicate sbom.cdx.json "${ref}@${DIGEST}"
+          done

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -137,6 +137,26 @@ jobs:
             "thetechnetwork/it-tools@${DIGEST}" \
             "ghcr.io/thetechnetwork/it-tools@${DIGEST}"
 
+      - name: Generate CycloneDX SBOM (${{ matrix.target }})
+        uses: anchore/sbom-action@0b82b0b1a22399a1c542d4d656f70cd903571b5c # v0.21.1
+        with:
+          image: ghcr.io/thetechnetwork/it-tools@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest the SBOM (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          # Signed, transparency-logged CycloneDX attestation on each registry
+          # ref by digest (complements the buildkit sbom: true attestation).
+          for ref in "thetechnetwork/it-tools" "ghcr.io/thetechnetwork/it-tools"; do
+            cosign attest --yes --type cyclonedx \
+              --predicate sbom.cdx.json "${ref}@${DIGEST}"
+          done
+
   github-release:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -196,11 +216,16 @@ jobs:
             - **rootless** (nginx-unprivileged, non-root, port 8080): `:latest-rootless`, `:${{ env.RELEASE_VERSION }}-rootless`
             - **distroless** (static-web-server, non-root, port 8080): `:latest-distroless`, `:${{ env.RELEASE_VERSION }}-distroless`
 
-            All images are signed with cosign (keyless) and ship SBOM + SLSA
-            provenance attestations. Verify:
+            All images are signed with cosign (keyless) and ship SLSA provenance
+            plus a cosign-signed CycloneDX SBOM attestation. Verify:
 
             ```sh
             cosign verify \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/' \
+              thetechnetwork/it-tools:${{ env.RELEASE_VERSION }}
+
+            cosign verify-attestation --type cyclonedx \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/' \
               thetechnetwork/it-tools:${{ env.RELEASE_VERSION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,14 +902,15 @@ const value = useVModel(props, 'value', emit);
   a strict CSP still needs validating against Monaco, web workers and any
   `eval`/wasm the tools use.
 - **Supply chain**: published images (release + nightly, all variants, both
-  registries) ship a build SBOM and SLSA provenance attestation and are signed
+  registries) ship a build SBOM and SLSA provenance attestation, are signed
   with **cosign keyless** (Sigstore/OIDC; identity = the GitHub Actions workflow,
-  recorded in the public transparency log). Verify with `cosign verify
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-  --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/'
-  thetechnetwork/it-tools:latest` (see README "Verify image signatures"). CI's
-  Trivy scan of each image variant is a **blocking** gate on fixable
-  HIGH/CRITICAL vulnerabilities.
+  recorded in the public transparency log), and additionally carry a
+  **cosign-signed CycloneDX SBOM attestation** (generated with
+  `anchore/sbom-action`, attested with `cosign attest --type cyclonedx`). Verify
+  with `cosign verify` / `cosign verify-attestation --type cyclonedx` (see README
+  "Verify image signatures"). Each image variant's CI Trivy scan runs in two
+  tiers: a report-only full audit (includes unfixed CVEs, for visibility) and a
+  **blocking** gate that fails only on *fixable* HIGH/CRITICAL.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ cosign verify \
 Images also ship a build [SBOM](https://docs.docker.com/build/metadata/attestations/sla-sbom/)
 and [SLSA provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance/)
 attestation; inspect them with `docker buildx imagetools inspect thetechnetwork/it-tools:latest`.
+On top of that, a CycloneDX SBOM is published as a cosign-signed attestation you
+can verify (and pipe into a policy engine or vulnerability scanner):
+
+```sh
+cosign verify-attestation --type cyclonedx \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '(?i)^https://github.com/thetechnetwork/it-tools/' \
+  thetechnetwork/it-tools:latest
+```
 
 <details>
 <summary>Upstream images (<code>CorentinTh/it-tools</code>)</summary>


### PR DESCRIPTION
### Description

Follow-up to the cosign signing / Trivy gate work (#730).

**1. Signed CycloneDX SBOM attestation on every image.** Both publishing workflows (`releases.yml`, `docker-nightly-release.yml`) now generate a CycloneDX SBOM from the pushed digest (`anchore/sbom-action`) and sign it as a cosign attestation (`cosign attest --type cyclonedx`, keyless/OIDC, recorded in the transparency log) — for all variants, both registries. This complements the existing buildkit `sbom: true` attestation by making the SBOM verifiable with `cosign verify-attestation`.

**2. Two-tier Trivy in CI, so we can see what's blocked before it blocks.** The `docker-image` job now runs Trivy twice:
- **Full audit** (new, report-only): `ignore-unfixed: false` → the log shows the complete HIGH/CRITICAL exposure, fixable *and* unfixed. This is the "what's lurking" view.
- **Gate** (unchanged): `ignore-unfixed: true`, `exit-code: 1` → fails only on a *fixable* HIGH/CRITICAL, i.e. something a rebuild or base-image bump can actually resolve.

This directly answers "review what will get blocked": the gate blocks only the fixable set (baseline 0), while the audit surfaces the rest without failing CI. Because I have no local Docker/Trivy in this environment, the audit runs in this PR's CI (the `docker-image` job fires since `ci.yml` changed) — I'll read the results and, if the audit surfaces anything fixable, push a base-image bump before this merges.

**3. Docs.** README + release notes gain `cosign verify-attestation --type cyclonedx`; CLAUDE.md supply-chain / CI docs updated.

### Additional context

- Attestation and audit are additive; nothing about how images are built or served changes.
- The SBOM/attest steps only run on a real tag push / nightly schedule, so they can't exercise in this PR's CI — the workflow YAML validates. The Trivy audit **does** run here.
- `anchore/sbom-action` pinned by commit SHA (`v0.21.1`) per repo convention.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (CI / supply-chain security)

### Before submitting the PR, please make sure you do the following

- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Workflow YAML validated; the new Trivy audit is exercised by the existing `docker-image` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_