### PR TITLE
fix(build): migrate optimizeDeps.esbuildOptions to rolldownOptions

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -120,9 +120,11 @@ export default defineConfig({
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(process.env.npm_package_version),
   },
   optimizeDeps: {
-    esbuildOptions: {
-      define: {
-        global: 'globalThis',
+    rolldownOptions: {
+      transform: {
+        define: {
+          global: 'globalThis',
+        },
       },
     },
   },


### PR DESCRIPTION
### Description

Vite 8 pre-bundles dependencies with **Rolldown** and has deprecated `optimizeDeps.esbuildOptions`, so starting the dev server (or a build) prints:

> You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.

This migrates the one usage in `vite.config.ts` — the `global: 'globalThis'` define applied during dependency pre-bundling (the Node-polyfill shim for `buffer`/`stream`/etc.) — to the Rolldown equivalent. In Rolldown's options, `define` lives under `transform`, so:

```diff
 optimizeDeps: {
-  esbuildOptions: {
-    define: {
-      global: 'globalThis',
+  rolldownOptions: {
+    transform: {
+      define: {
+        global: 'globalThis',
+      },
     },
   },
 },
```

The nesting was confirmed against the installed `rolldown@1.1.5` type definitions (`InputOptions.transform.define: Record<string, string>`).

### Additional context

Verified locally:
- `pnpm dev` — server boots on Vite 8.1.5, dependency optimizer runs, and the deprecation warning is **gone**.
- `pnpm build` — succeeds (`✓ built in ~29s`, PWA generated), no config error.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Verified with `pnpm dev` (warning gone) and `pnpm build` (succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_