### PR TITLE
ci(security): upload Trivy findings to code scanning and add dependency review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,8 @@ jobs:
   # container serves, nginx variants reach a healthy HEALTHCHECK, and all three
   # serve identically (security headers, gzip, asset caching, SPA fallback) -
   # the shared serving contract that keeps the variants in lockstep. Also scans
-  # each image with Trivy, which fails the job on a fixable HIGH/CRITICAL
+  # each image with Trivy: findings are uploaded to GitHub code scanning (the
+  # Security tab) and a blocking gate fails the job on a fixable HIGH/CRITICAL
   # (ignore-unfixed keeps un-actionable base-image CVEs from blocking). Gated to
   # Docker changes (via toolchain-changes) so ordinary PRs skip the image
   # builds; always on main.
@@ -304,6 +305,10 @@ jobs:
       (github.event_name != 'pull_request' || needs.toolchain-changes.outputs.docker == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # security-events: write lets the Trivy SARIF upload reach code scanning.
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -400,17 +405,26 @@ jobs:
         if: always()
         run: docker rm -f it-tools-ci || true
 
-      # Full audit: report-only, includes unfixed CVEs, so the log shows the
-      # complete HIGH/CRITICAL exposure (fixable and not) for visibility. Never
-      # blocks - it is the "what's lurking" view.
-      - name: Trivy full audit (report-only, includes unfixed)
+      # Full audit -> GitHub code scanning (Security tab). Report-only (exit 0)
+      # and includes unfixed CVEs, so the Security tab tracks the complete
+      # HIGH/CRITICAL exposure (fixable and not) over time and annotates PRs.
+      # The blocking gate below is what actually fails the build.
+      - name: Trivy full audit (SARIF)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: it-tools:${{ matrix.target }}
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: false
-          format: table
+          format: sarif
+          output: 'trivy-${{ matrix.target }}.sarif'
           exit-code: '0'
+
+      - name: Upload Trivy SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        with:
+          sarif_file: 'trivy-${{ matrix.target }}.sarif'
+          category: 'trivy-${{ matrix.target }}'
 
       # Gate: fails the job only on a *fixable* HIGH/CRITICAL - something an
       # image rebuild or base-image bump can actually resolve.
@@ -422,3 +436,22 @@ jobs:
           ignore-unfixed: true
           format: table
           exit-code: '1'
+
+  # Review dependency changes on PRs: fail when a PR introduces a dependency
+  # with a known HIGH/CRITICAL vulnerability. Complements Renovate (which keeps
+  # existing deps current) by gating what a change brings in.
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,10 +719,16 @@ Jobs:
    `Dockerfile`) and verifies them in a matrix: the container serves, nginx
    variants reach a healthy HEALTHCHECK, and all three serve the same contract
    (security headers, gzip, asset caching, SPA fallback). Also scans each image
-   with Trivy, which **fails the job on a fixable HIGH/CRITICAL**
-   (`ignore-unfixed` keeps un-actionable base-image CVEs from blocking). Gated
-   to Docker changes (`Dockerfile`, `docker/`, `.dockerignore`) via
-   **toolchain-changes**; always runs on pushes to main.
+   with Trivy: the full result (incl. unfixed) is uploaded to **GitHub code
+   scanning** (Security tab, one `category` per variant) via SARIF, and a
+   blocking gate **fails the job on a fixable HIGH/CRITICAL** (`ignore-unfixed`
+   keeps un-actionable base-image CVEs from blocking). Needs
+   `security-events: write`. Gated to Docker changes (`Dockerfile`, `docker/`,
+   `.dockerignore`) via **toolchain-changes**; always runs on pushes to main.
+6. **dependency-review**: On PRs, `actions/dependency-review-action` fails the
+   build when a PR introduces a dependency with a known HIGH/CRITICAL
+   vulnerability (comments a summary on failure). Complements Renovate, which
+   keeps existing deps current.
 
 **Caches**:
 - Vite build cache
@@ -762,7 +768,10 @@ the same SBOM + provenance attestations and keyless cosign signing as the
 release workflow.
 
 > Static analysis (SAST) runs via GitHub code-scanning **default setup**
-> (configured in repo settings), not a workflow file in this repo.
+> (configured in repo settings), not a workflow file in this repo. The Trivy
+> image SARIF (from **ci.yml**'s docker-image job) is uploaded into the same
+> code-scanning surface under its own `trivy-*` categories, so container CVEs
+> and CodeQL findings share the Security tab.
 
 ### Concurrency
 


### PR DESCRIPTION
### Description

Two additive, low-risk CI security integrations. (First of two follow-ups — a Content-Security-Policy change will come separately after local validation against Monaco/workers.)

**1. Trivy findings → GitHub code scanning (Security tab).** The `docker-image` job already scanned each image variant with Trivy, but results only went to the job log. Now the full audit (all HIGH/CRITICAL, including unfixed) is emitted as SARIF and uploaded to code scanning with one `category` per variant (`trivy-standard` / `trivy-rootless` / `trivy-distroless`), so container CVEs are tracked over time, annotate PRs, and share the Security tab with the existing CodeQL default setup. The job gains `security-events: write`.
- The blocking gate is **unchanged** — it still fails the build only on a *fixable* HIGH/CRITICAL (`ignore-unfixed: true`). The SARIF step is report-only (`exit-code: 0`).

**2. `dependency-review` on PRs.** A new PR-only job runs `actions/dependency-review-action` to fail the build when a change introduces a dependency with a known HIGH/CRITICAL vulnerability, commenting a summary on failure. This complements Renovate: Renovate keeps existing deps current; dependency-review gates what a PR *brings in*.

### Additional context

- Both new actions (`github/codeql-action/upload-sarif` v3.37.3, `actions/dependency-review-action` v4.9.0) are pinned by commit SHA per repo convention.
- The `docker-image` job runs on this PR (it touches `ci.yml`), so the SARIF upload path is exercised here; `dependency-review` runs on every PR.
- No change to what the images contain or serve.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (CI / security)

### Before submitting the PR, please make sure you do the following

- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Workflow YAML validated; the Trivy SARIF path is exercised by the `docker-image` job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_