### PR TITLE
fix(meta-tag-generator): emit content= on meta tags instead of value=

### DIFF
--- a/src/tools/meta-tag-generator/meta-tag-generator.service.test.ts
+++ b/src/tools/meta-tag-generator/meta-tag-generator.service.test.ts
@@ -10,9 +10,9 @@ describe('meta-tag-generator', () => {
         description: 'My description',
       });
 
-      expect(html).toContain('<meta property="og:type" value="website" />');
-      expect(html).toContain('<meta property="og:title" value="My title" />');
-      expect(html).toContain('<meta property="og:description" value="My description" />');
+      expect(html).toContain('<meta property="og:type" content="website" />');
+      expect(html).toContain('<meta property="og:title" content="My title" />');
+      expect(html).toContain('<meta property="og:description" content="My description" />');
     });
 
     it('moves twitter-prefixed keys into dedicated twitter meta tags', () => {
@@ -23,8 +23,8 @@ describe('meta-tag-generator', () => {
         'twitter:site': '@my-site',
       });
 
-      expect(html).toContain('<meta name="twitter:card" value="summary_large_image" />');
-      expect(html).toContain('<meta name="twitter:site" value="@my-site" />');
+      expect(html).toContain('<meta name="twitter:card" content="summary_large_image" />');
+      expect(html).toContain('<meta name="twitter:site" content="@my-site" />');
       expect(html).not.toContain('og:twitter');
     });
 
@@ -35,7 +35,7 @@ describe('meta-tag-generator', () => {
         'twitter:card': 'summary_large_image',
       });
 
-      expect(html).toContain('<meta name="twitter:title" value="My title" />');
+      expect(html).toContain('<meta name="twitter:title" content="My title" />');
     });
 
     it('generates the full snippet for a typical website config', () => {
@@ -48,13 +48,13 @@ describe('meta-tag-generator', () => {
 
       expect(html).toBe([
         '<!-- og meta -->',
-        '<meta property="og:type" value="website" />',
-        '<meta property="og:title" value="My title" />',
+        '<meta property="og:type" content="website" />',
+        '<meta property="og:title" content="My title" />',
         '',
         '<!-- twitter meta -->',
-        '<meta name="twitter:card" value="summary_large_image" />',
-        '<meta name="twitter:site" value="@site" />',
-        '<meta name="twitter:title" value="My title" />',
+        '<meta name="twitter:card" content="summary_large_image" />',
+        '<meta name="twitter:site" content="@site" />',
+        '<meta name="twitter:title" content="My title" />',
       ].join('\n'));
     });
 

--- a/src/tools/meta-tag-generator/oggen.ts
+++ b/src/tools/meta-tag-generator/oggen.ts
@@ -1,7 +1,8 @@
 // Open Graph / Twitter <meta> generator, vendored from the (unmaintained,
 // zero-dependency) @it-tools/oggen package (MIT, CorentinTh) to drop the
-// abandoned dependency. Ported verbatim from its dist - behaviour is unchanged
-// (including that it emits `value="..."` rather than `content="..."`).
+// abandoned dependency. Ported from its dist, with one correctness fix: <meta>
+// tags carry their data in the `content` attribute (what OG/Twitter crawlers
+// read), not `value` - the original emitted the invalid `value="..."`.
 
 export type { MetadataConfig, MetadataValue };
 export { generateMeta };
@@ -69,7 +70,7 @@ function buildMetaStrings({ flatMetadata, type }: { flatMetadata: FlatMeta[]; ty
 }
 
 function metaToString({ flatMetadata: { key, value }, type }: { flatMetadata: FlatMeta; type: string }): string {
-  return `<meta ${type.trim()}="${key.trim()}" value="${value.trim()}" />`;
+  return `<meta ${type.trim()}="${key.trim()}" content="${value.trim()}" />`;
 }
 
 function flattenMetadata(metadata: unknown, { separator = ':', basePrefix = '' }: { separator?: string; basePrefix?: string } = {}): FlatMeta[] {


### PR DESCRIPTION
### Description

The meta-tag-generator emitted `<meta property="og:title" value="…" />`, but `<meta>` tags carry their data in the **`content`** attribute — `value` is not a valid `<meta>` attribute. Every social crawler (Facebook, X/Twitter, LinkedIn, Slack, Discord, …) reads `content` and ignores `value`, so the generated snippet **did not actually work** when pasted into a page's `<head>`.

This was a long-standing upstream mistake baked into `@it-tools/oggen` — its code, its README examples, and this tool's tests all used `value=`. (It was carried over verbatim when the package was vendored in #744, deliberately kept as a pure refactor.) This PR corrects the emitted attribute to `content=` and updates the test assertions that encoded the bug.

**Before**
```html
<meta property="og:title" value="My title" />
<meta name="twitter:card" value="summary_large_image" />
```
**After**
```html
<meta property="og:title" content="My title" />
<meta name="twitter:card" content="summary_large_image" />
```

### Additional context

- One-character change in `oggen.ts` (`value` → `content`) plus the matching test updates; the tool's 5 unit tests pass.
- Confirmed against the Open Graph protocol and the HTML `<meta>` element spec — there is no valid use of `value=` on OG/Twitter meta tags.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Included the failing-then-passing tests (assertions updated from `value=` to `content=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_