### PR TITLE
fix(ocr): fail fast when language data is unavailable instead of hanging

### DIFF
--- a/src/tools/ocr-image-to-text/ocr-image-to-text.service.test.ts
+++ b/src/tools/ocr-image-to-text/ocr-image-to-text.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { createWorker, recognize, terminate } = vi.hoisted(() => {
   const recognize = vi.fn(async () => ({ data: { text: 'hello world' } }));
@@ -8,6 +8,15 @@ const { createWorker, recognize, terminate } = vi.hoisted(() => {
 });
 
 vi.mock('tesseract.js', () => ({ createWorker }));
+
+// The recognizer preflights each language's .traineddata with a HEAD request;
+// stub fetch as reachable by default (individual tests override it).
+const fetchMock = vi.fn(async () => ({ ok: true, status: 200 } as Response));
+beforeEach(() => {
+  fetchMock.mockClear();
+  fetchMock.mockResolvedValue({ ok: true, status: 200 } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+});
 
 const { createRecognizer, getAssetsBaseUrl, recognizeText, resolveAssetsBase, SUPPORTED_LANGUAGES } = await import('./ocr-image-to-text.service');
 
@@ -68,5 +77,25 @@ describe('ocr-image-to-text', () => {
     expect(createWorker).toHaveBeenCalledTimes(1);
     expect(recognize).toHaveBeenCalledTimes(2);
     expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('preflights each language and HEADs its .traineddata before starting the worker', async () => {
+    fetchMock.mockClear();
+    await recognizeText({ image: 'x', languages: ['eng', 'fra'] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/tesseract\/.+\/tessdata\/eng\.traineddata$/),
+      expect.objectContaining({ method: 'HEAD' }),
+    );
+  });
+
+  it('fails fast with a clear error (not a hang) when a language is unavailable', async () => {
+    createWorker.mockClear();
+    fetchMock.mockResolvedValue({ ok: false, status: 404 } as Response);
+
+    await expect(recognizeText({ image: 'x', languages: ['jpn'] })).rejects.toThrow(/jpn.*unavailable/i);
+    // The worker is never started when the data can't be fetched.
+    expect(createWorker).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/ocr-image-to-text/ocr-image-to-text.service.ts
+++ b/src/tools/ocr-image-to-text/ocr-image-to-text.service.ts
@@ -87,6 +87,24 @@ function langDir(quality: OcrQuality): string {
   return quality === 'best' ? 'tessdata-best' : 'tessdata';
 }
 
+// Fail fast (with a clear, catchable error) if a language's data can't be
+// fetched. tesseract.js does NOT reject createWorker when a .traineddata is
+// missing/unreachable - it hits an internal race and hangs - so without this
+// the UI would spin forever with no message when the asset host is unpopulated
+// or a download drops.
+async function assertLanguageAvailable(url: string, language: string): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'HEAD', cache: 'no-store' });
+  }
+  catch {
+    throw new Error(`Could not reach the OCR data for "${language}". Check your connection and try again.`);
+  }
+  if (!response.ok) {
+    throw new Error(`OCR data for "${language}" is unavailable (HTTP ${response.status}).`);
+  }
+}
+
 // Create one worker for the given languages/quality and reuse it across many
 // images before terminating - much faster than re-initializing per image when
 // processing a batch (or the pages of a PDF).
@@ -100,13 +118,17 @@ async function createRecognizer({
   onProgress?: (info: OcrProgress) => void;
 }): Promise<Recognizer> {
   const base = getAssetsBaseUrl();
+  const dir = langDir(quality);
+
+  // Confirm every language's data is reachable before starting the worker.
+  await Promise.all(languages.map(language => assertLanguageAvailable(`${base}/${dir}/${language}.traineddata`, language)));
 
   // Pass a plain array: tesseract.js posts the languages to its worker, and a
   // reactive/proxied array would fail structured clone ("could not be cloned").
   const worker = await createWorker([...languages], 1, {
     workerPath: `${base}/worker.min.js`,
     corePath: `${base}/core`,
-    langPath: `${base}/${langDir(quality)}`,
+    langPath: `${base}/${dir}`,
     gzip: false, // the asset host serves raw .traineddata, not .gz
     logger: (message) => {
       onProgress?.({ status: message.status, progress: message.progress });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -173,10 +173,10 @@ export default defineConfig({
       // get locked in as the new floor. Commit the bumped values.
       thresholds: {
         autoUpdate: true,
-        lines: 64.15,
-        statements: 64.87,
-        functions: 66.35,
-        branches: 73.37,
+        lines: 64.27,
+        statements: 65.01,
+        functions: 66.47,
+        branches: 73.45,
       },
     },
   },


### PR DESCRIPTION
### Description

Fixes the OCR tool hanging (spinner forever, no error) when a selected language's data can't be fetched — which is what "selecting multiple languages crashes" turned out to be.

**Root cause:** tesseract.js does **not** reject `createWorker` when a `.traineddata` is missing/unreachable. It hits an internal resolve-on-undefined race and emits **uncaught** `Error: initialization failed` / `Cannot read properties of undefined (reading 'resolve')`, while the `createWorker` promise never settles. So `await createRecognizer(...)` hung and the spinner never cleared — no toast, no recovery. This happens whenever the asset host isn't fully populated (the pending R2 setup) or a download drops mid-flight.

**Fix:** preflight each selected language with a `HEAD` on its `.traineddata` before starting the worker. If any is unreachable, throw a clear, catchable error (surfaced as a toast, spinner reset) instead of starting a worker that will hang.

### Additional context

Reproduced and verified in a real browser under the strict CSP:

- **Before:** selecting only an unavailable language → `pageerror: initialization failed` + `TypeError … reading 'resolve'`, no toast, spinner stuck.
- **After:** same case → toast **`OCR data for "jpn" is unavailable (HTTP 404)`**, page responsive, **zero uncaught errors**.
- Available languages (single **and** multi — verified English + French + German) work unchanged; the preflight is a cheap `HEAD` that passes and proceeds as before.

Unit tests added: the recognizer `HEAD`s each language before starting the worker, and an unavailable language rejects with a clear message without ever calling `createWorker`. Coverage auto-ratcheted up.

This also improves the real-world flaky-connection case, and gives a clear signal until the production R2 bucket is populated.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Targets the default branch (`main`).
- [x] Checked there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Included tests (preflight + unavailable-language rejection) and verified the fix end-to-end in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_