### PR TITLE
ci(ocr-assets): skip re-sync when the version is already published

### DIFF
--- a/.github/workflows/ocr-assets.yml
+++ b/.github/workflows/ocr-assets.yml
@@ -4,17 +4,22 @@
 # there at runtime, so this keeps the deploy lean and works identically across
 # Cloudflare, Vercel, Netlify and Docker.
 #
-# Runs on manual dispatch, weekly (to pick up new tessdata_fast), and whenever the
-# tesseract.js version or the asset scripts change on main. It no-ops (does not
-# fail) until the R2_* secrets are configured, so it stays green before the bucket
-# is set up.
+# The version-pinned path is immutable, so a given version only needs publishing
+# ONCE. This runs on manual dispatch and whenever the tesseract.js version or the
+# asset scripts change on main; a `check` step reads the published manifest and
+# skips prepare + upload entirely when the current version is already complete,
+# so re-runs don't re-download ~200 MB of tessdata for nothing. Use the `force`
+# dispatch input to re-publish regardless. It no-ops (does not fail) until the
+# R2_* secrets are configured, so it stays green before the bucket is set up.
 name: ocr-assets
 
 on:
   workflow_dispatch:
-  schedule:
-    # Weekly, Monday 05:00 UTC.
-    - cron: '0 5 * * 1'
+    inputs:
+      force:
+        description: 'Re-publish even if this version is already synced'
+        type: boolean
+        default: false
   push:
     branches: [ "main" ]
     paths:
@@ -22,6 +27,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'scripts/prepare-tesseract.mjs'
       - 'scripts/sync-ocr-assets.mjs'
+      - 'scripts/ocr-assets.config.mjs'
       - '.github/workflows/ocr-assets.yml'
 
 concurrency:
@@ -35,6 +41,12 @@ jobs:
   sync:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    env:
+      OCR_ALL_LANGS: '1'
+      OCR_BEST: '1'
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -59,14 +71,30 @@ jobs:
         if: steps.cfg.outputs.configured == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Prepare assets (engine + all languages, fast + best)
-        if: steps.cfg.outputs.configured == 'true'
-        run: OCR_ALL_LANGS=1 OCR_BEST=1 pnpm script:ocr:assets
-
-      - name: Upload to R2
+      - name: Check whether this version is already published
+        id: check
         if: steps.cfg.outputs.configured == 'true'
         env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          FORCE: ${{ inputs.force && '1' || '' }}
+        run: |
+          result=$(node scripts/sync-ocr-assets.mjs --check || echo not-synced)
+          echo "check: $result"
+          if [ "$result" = "synced" ]; then
+            echo "synced=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "synced=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Already published - nothing to do
+        if: steps.cfg.outputs.configured == 'true' && steps.check.outputs.synced == 'true'
+        run: echo "This tesseract version is already published to R2; skipping prepare + upload."
+
+      - name: Prepare assets (engine + all languages, fast + best)
+        if: steps.cfg.outputs.configured == 'true' && steps.check.outputs.synced != 'true'
+        run: pnpm script:ocr:assets
+
+      - name: Upload to R2
+        if: steps.cfg.outputs.configured == 'true' && steps.check.outputs.synced != 'true'
+        env:
+          FORCE: ${{ inputs.force && '1' || '' }}
         run: pnpm script:ocr:sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,17 +769,24 @@ release workflow.
 
 #### 7. **ocr-assets.yml** - OCR Asset Publishing
 
-Publishes the Tesseract OCR assets (engine + every supported language) to the
-first-party R2 bucket behind `assets.thetech.network`, under a path versioned by
-the tesseract.js version (`tesseract/<version>/`). Runs on manual dispatch,
-weekly, and when the tesseract.js version or the asset scripts change on main. It
-prepares the assets (`scripts/prepare-tesseract.mjs` with `OCR_ALL_LANGS=1`) and
+Publishes the Tesseract OCR assets (engine + every supported language, `fast`
+and `best`) to the first-party R2 bucket behind `assets.thetech.network`, under a
+path versioned by the tesseract.js version (`tesseract/<version>/`). Because that
+path is immutable, a version only needs publishing once: the workflow runs on
+manual dispatch and when the tesseract.js version or the asset scripts change on
+main, and a `check` step reads the published `manifest.json` and **skips prepare +
+upload when the version is already complete** (so re-runs don't re-download
+~200 MB of tessdata for nothing); a `force` dispatch input re-publishes anyway.
+The language set + quality sources live in `scripts/ocr-assets.config.mjs` (shared
+by prepare and sync so the manifest check stays in lockstep). It prepares the
+assets (`scripts/prepare-tesseract.mjs` with `OCR_ALL_LANGS=1 OCR_BEST=1`) and
 mirrors them with `scripts/sync-ocr-assets.mjs`, which shells out to the
-pre-installed `aws` CLI (R2 speaks the S3 API - no AWS SDK added to the repo).
-Needs the `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` secrets;
-it no-ops (staying green) until they are configured. The Image-to-text (OCR) tool
-fetches these assets same-origin-free at runtime, which is why the CSP allows
-`assets.thetech.network` on `script-src`/`connect-src`.
+pre-installed `aws` CLI (R2 speaks the S3 API - no AWS SDK added to the repo) and
+writes the manifest on success. Needs the `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID` and
+`R2_SECRET_ACCESS_KEY` secrets; it no-ops (staying green) until they are
+configured. The Image-to-text (OCR) tool fetches these assets same-origin-free at
+runtime, which is why the CSP allows `assets.thetech.network` on
+`script-src`/`connect-src`.
 
 > Static analysis (SAST) runs via GitHub code-scanning **default setup**
 > (configured in repo settings), not a workflow file in this repo. The Trivy

--- a/scripts/ocr-assets.config.mjs
+++ b/scripts/ocr-assets.config.mjs
@@ -1,0 +1,58 @@
+// Shared config for the OCR asset scripts (prepare-tesseract.mjs and
+// sync-ocr-assets.mjs) so the language set and quality sources stay in lockstep,
+// and so the sync script can tell whether a version is already fully published.
+import process from 'node:process';
+
+// The broad set uploaded to R2 / baked into the offline Docker image.
+export const ALL_LANGUAGES = [
+  'eng',
+  'spa',
+  'fra',
+  'deu',
+  'ita',
+  'por',
+  'nld',
+  'pol',
+  'ron',
+  'ces',
+  'hun',
+  'swe',
+  'dan',
+  'fin',
+  'nor',
+  'tur',
+  'ell',
+  'rus',
+  'ukr',
+  'bul',
+  'srp',
+  'ara',
+  'heb',
+  'hin',
+  'tha',
+  'vie',
+  'ind',
+  'chi_sim',
+  'chi_tra',
+  'jpn',
+  'kor',
+  'osd',
+];
+
+// The OCR tool's quality toggle picks fast (tessdata_fast) or best
+// (tessdata_best). Each is served under its own subdir of tesseract/<version>/.
+export const QUALITY_SOURCES = {
+  fast: { dir: 'tessdata', base: 'https://cdn.jsdelivr.net/gh/tesseract-ocr/tessdata_fast@main' },
+  best: { dir: 'tessdata-best', base: 'https://cdn.jsdelivr.net/gh/tesseract-ocr/tessdata_best@main' },
+};
+
+// Default to English only so `pnpm dev` is fast; OCR_ALL_LANGS=1 selects the
+// full set (the sync workflow sets it).
+export function getLanguages() {
+  return process.env.OCR_ALL_LANGS ? ALL_LANGUAGES : ['eng'];
+}
+
+// fast always; add best with OCR_BEST=1 (the sync workflow sets it).
+export function getQualities() {
+  return process.env.OCR_BEST ? ['fast', 'best'] : ['fast'];
+}

--- a/scripts/prepare-tesseract.mjs
+++ b/scripts/prepare-tesseract.mjs
@@ -18,6 +18,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { getLanguages, getQualities, QUALITY_SOURCES } from './ocr-assets.config.mjs';
 
 const require = createRequire(import.meta.url);
 const root = path.resolve(fileURLToPath(import.meta.url), '../..');
@@ -26,58 +27,15 @@ const version = require('tesseract.js/package.json').version;
 
 const outDir = path.join(root, 'public', 'tesseract', version);
 const coreDir = path.join(outDir, 'core');
-const tessdataDir = path.join(outDir, 'tessdata');
-const tessdataBestDir = path.join(outDir, 'tessdata-best');
 
-// The broad set baked into the offline image / uploaded to R2.
-const ALL_LANGUAGES = [
-  'eng',
-  'spa',
-  'fra',
-  'deu',
-  'ita',
-  'por',
-  'nld',
-  'pol',
-  'ron',
-  'ces',
-  'hun',
-  'swe',
-  'dan',
-  'fin',
-  'nor',
-  'tur',
-  'ell',
-  'rus',
-  'ukr',
-  'bul',
-  'srp',
-  'ara',
-  'heb',
-  'hin',
-  'tha',
-  'vie',
-  'ind',
-  'chi_sim',
-  'chi_tra',
-  'jpn',
-  'kor',
-  'osd',
-];
-
-// Default to English only so `pnpm dev` is fast; opt into the full set with
-// OCR_ALL_LANGS=1 (the asset-sync workflow does this).
-const languages = process.env.OCR_ALL_LANGS ? ALL_LANGUAGES : ['eng'];
-
-// The OCR tool's quality toggle picks fast (tessdata_fast) or best
-// (tessdata_best). Fetch fast always; add best with OCR_BEST=1 (the sync
-// workflow sets it so both qualities are published).
-const QUALITIES = [
-  { name: 'tessdata_fast', base: 'https://cdn.jsdelivr.net/gh/tesseract-ocr/tessdata_fast@main', destDir: tessdataDir },
-  ...(process.env.OCR_BEST
-    ? [{ name: 'tessdata_best', base: 'https://cdn.jsdelivr.net/gh/tesseract-ocr/tessdata_best@main', destDir: tessdataBestDir }]
-    : []),
-];
+// Languages and qualities to prepare (English/fast for `pnpm dev`, the full set
+// for the sync workflow via OCR_ALL_LANGS=1 / OCR_BEST=1).
+const languages = getLanguages();
+const QUALITIES = getQualities().map(quality => ({
+  name: quality,
+  base: QUALITY_SOURCES[quality].base,
+  destDir: path.join(outDir, QUALITY_SOURCES[quality].dir),
+}));
 
 async function copyEngine() {
   const tesseractPkg = require.resolve('tesseract.js/package.json');

--- a/scripts/sync-ocr-assets.mjs
+++ b/scripts/sync-ocr-assets.mjs
@@ -13,6 +13,10 @@
 //   R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
 // Optional: R2_BUCKET (default "thetechnetwork-assets"), FORCE=1 (re-upload
 // files that already exist), DRY_RUN=1 (print the plan, touch nothing).
+//
+// `--check` prints "synced" if this version's manifest already covers the
+// expected languages/qualities (so the workflow can skip prepare + upload
+// entirely), else "not-synced". A successful sync writes that manifest.
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
@@ -20,6 +24,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { getLanguages, getQualities } from './ocr-assets.config.mjs';
 
 const require = createRequire(import.meta.url);
 const root = path.resolve(fileURLToPath(import.meta.url), '../..');
@@ -28,8 +33,10 @@ const version = require('tesseract.js/package.json').version;
 const localDir = path.join(root, 'public', 'tesseract', version);
 const bucket = process.env.R2_BUCKET || 'thetechnetwork-assets';
 const keyPrefix = `tesseract/${version}`;
+const manifestKey = `${keyPrefix}/manifest.json`;
 const dryRun = !!process.env.DRY_RUN;
 const force = !!process.env.FORCE;
+const checkOnly = process.argv.includes('--check');
 
 // Content-hashed, version-pinned path -> immutable, cache for a year.
 const CACHE_CONTROL = 'public, max-age=31536000, immutable';
@@ -103,7 +110,59 @@ function objectExists(key) {
   return result !== null;
 }
 
-async function main() {
+// The manifest records which languages/qualities have been published for this
+// version. It lets `--check` tell whether there is anything to do without
+// re-downloading ~200 MB of tessdata every run.
+function readManifest() {
+  try {
+    const out = execFileSync('aws', ['s3', 'cp', `s3://${bucket}/${manifestKey}`, '-', '--endpoint-url', endpoint()], {
+      env: awsEnv(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return JSON.parse(out.toString());
+  }
+  catch {
+    return null;
+  }
+}
+
+function writeManifest() {
+  const manifest = JSON.stringify({ version, languages: getLanguages(), qualities: getQualities() });
+  execFileSync('aws', [
+    's3',
+    'cp',
+    '-',
+    `s3://${bucket}/${manifestKey}`,
+    '--content-type',
+    'application/json',
+    '--cache-control',
+    'no-cache',
+    '--endpoint-url',
+    endpoint(),
+  ], { env: awsEnv(), input: manifest });
+  console.log('  wrote manifest.json');
+}
+
+// True if the published manifest already covers every expected language/quality.
+function isAlreadySynced() {
+  const manifest = readManifest();
+  if (!manifest) {
+    return false;
+  }
+  const languages = manifest.languages ?? [];
+  const qualities = manifest.qualities ?? [];
+  return getLanguages().every(language => languages.includes(language))
+    && getQualities().every(quality => qualities.includes(quality));
+}
+
+async function runCheck() {
+  requireEnv();
+  const synced = !force && isAlreadySynced();
+  // Single-word stdout the workflow captures to decide whether to skip.
+  console.log(synced ? 'synced' : 'not-synced');
+}
+
+async function runSync() {
   if (!existsSync(localDir)) {
     throw new Error(`No assets at ${localDir} - run \`OCR_ALL_LANGS=1 pnpm script:ocr:assets\` first.`);
   }
@@ -150,8 +209,17 @@ async function main() {
   }
 
   if (!dryRun) {
+    writeManifest();
     console.log(`Done: ${uploaded} uploaded (${(bytes / 1048576).toFixed(1)} MB), ${skipped} already present.`);
   }
+}
+
+async function main() {
+  if (checkOnly) {
+    await runCheck();
+    return;
+  }
+  await runSync();
 }
 
 main().catch((error) => {


### PR DESCRIPTION
### Description

Fixes the `ocr-assets` workflow re-doing the whole sync on every run. Each run re-downloaded the full ~200 MB `tessdata` set from jsdelivr and re-walked it, and a **weekly cron** triggered that for nothing — even though the version-pinned R2 path (`tesseract/<version>/`) is **immutable**, so a version only needs publishing once. (The weekly "pick up new tessdata" intent couldn't work anyway: skip-if-exists + the year-long immutable cache mean same-version updates never propagate.)

- **Drop the weekly schedule.** Keep manual dispatch + the version/script push trigger — the only times a publish is actually needed.
- **Skip when already synced.** `sync` now writes a `manifest.json` (languages + qualities) on success, and a new `--check` mode reports whether the published manifest already covers the expected set. The workflow runs the check first and **skips prepare + upload entirely** when the version is already complete, so re-runs are cheap no-ops instead of a full re-download. A **`force`** dispatch input re-publishes regardless.
- **Shared config.** Extract the language set + quality sources into `scripts/ocr-assets.config.mjs`, imported by both `prepare` and `sync` so the manifest check stays in lockstep (and a language-list change is detected automatically — the manifest won't cover the new set → it re-syncs).

### Additional context

- Verified locally: `prepare-tesseract.mjs` (now config-driven) and `sync --dry-run` work unchanged; lint clean; the workflow YAML parses (no `schedule`, `force` input present).
- The check **fails safe** — if `--check` can't run (e.g. missing creds), the step reports `not-synced` and the sync proceeds, so it never wrongly skips.
- No app/runtime changes; scripts + workflow + one doc line only.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other — CI/workflow efficiency

### Before submitting the PR, please make sure you do the following

- [x] Targets the default branch (`main`).
- [x] Checked there isn't already a PR that solves the problem the same way.
- [x] Provided a description that addresses **what** the PR is solving.
- [x] Validated the scripts (prepare + sync dry-run + `--check`), lint, and workflow YAML locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_