### PR TITLE
test(i18n): add tool i18n coverage floor and internationalise the recent tools

### DIFF
--- a/i18n-coverage.json
+++ b/i18n-coverage.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Auto-ratcheting floor for tool i18n coverage: the percentage of tools whose title and description are internationalised (a non-empty title+description in locales/en.yml AND a translate('tools.<name>.*') call in the tool's index.ts). The test in src/tools/i18n-coverage.test.ts fails when coverage drops below this floor, and raises it automatically on local runs when coverage improves (never lowers it). Commit the bumped value.",
+  "minCoveragePercent": 70
+}

--- a/i18n-coverage.json
+++ b/i18n-coverage.json
@@ -1,4 +1,4 @@
 {
   "_comment": "Auto-ratcheting floor for tool i18n coverage: the percentage of tools whose title and description are internationalised (a non-empty title+description in locales/en.yml AND a translate('tools.<name>.*') call in the tool's index.ts). The test in src/tools/i18n-coverage.test.ts fails when coverage drops below this floor, and raises it automatically on local runs when coverage improves (never lowers it). Commit the bumped value.",
-  "minCoveragePercent": 70
+  "minCoveragePercent": 83
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -392,3 +392,55 @@ tools:
   text-to-binary:
     title: Text to ASCII binary
     description: Convert text to its ASCII binary representation and vice-versa.
+
+  jwt-generator:
+    title: JWT generator
+    description: 'Sign and generate a JSON Web Token (JWT) from a payload and key - HS256/384/512, RS, PS, ES and EdDSA. Runs entirely in your browser; the key never leaves your device.'
+
+  color-contrast-checker:
+    title: Color contrast checker
+    description: 'Check the WCAG contrast ratio between a text and a background color, and see which accessibility levels (AA / AAA) it passes.'
+
+  data-storage-converter:
+    title: Data storage converter
+    description: 'Convert digital storage sizes between bits, bytes and their decimal (kB, MB, GB…) and binary (KiB, MiB, GiB…) multiples.'
+
+  text-line-tools:
+    title: Text line tools
+    description: 'Sort, deduplicate, reverse, shuffle, number, trim and filter the lines of a block of text.'
+
+  json-to-typescript:
+    title: JSON to TypeScript
+    description: 'Generate TypeScript interfaces from a JSON object or array, with nested types automatically extracted.'
+
+  csv-to-json:
+    title: CSV to JSON
+    description: 'Convert CSV (comma, semicolon or any delimiter) to JSON, with proper handling of quoted fields, escaped quotes and embedded newlines.'
+
+  duration-converter:
+    title: Duration converter
+    description: 'Convert a duration between nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days and weeks, with a human-readable breakdown.'
+
+  html-to-markdown:
+    title: HTML to Markdown
+    description: 'Convert HTML to clean Markdown, with headings, links, lists, emphasis and fenced code blocks.'
+
+  string-escape:
+    title: String escape / unescape
+    description: 'Escape or unescape a string using backslash sequences (\n, \t, \", \uXXXX…), as used in JSON, JavaScript and many programming languages.'
+
+  number-to-words:
+    title: Number to words
+    description: 'Spell out a number in English words (e.g. 1234 becomes "one thousand two hundred thirty-four"), with support for negatives and decimals.'
+
+  unicode-inspector:
+    title: Unicode inspector
+    description: 'Inspect a string character by character: Unicode code point, decimal value, HTML entity, and UTF-8 / UTF-16 byte sequences.'
+
+  markdown-toc-generator:
+    title: Markdown TOC generator
+    description: 'Generate a nested table of contents with GitHub-style anchor links from the headings of a Markdown document.'
+
+  json-sort-keys:
+    title: JSON sort keys
+    description: 'Recursively sort the keys of a JSON object to produce a canonical, diff-friendly output (array order is preserved).'

--- a/src/tools/color-contrast-checker/index.ts
+++ b/src/tools/color-contrast-checker/index.ts
@@ -1,10 +1,11 @@
 import { Contrast } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Color contrast checker',
+  name: translate('tools.color-contrast-checker.title'),
   path: '/color-contrast-checker',
-  description: 'Check the WCAG contrast ratio between a text and a background color, and see which accessibility levels (AA / AAA) it passes.',
+  description: translate('tools.color-contrast-checker.description'),
   keywords: ['color', 'contrast', 'checker', 'wcag', 'accessibility', 'a11y', 'ratio', 'aa', 'aaa', 'foreground', 'background'],
   component: () => import('./color-contrast-checker.vue'),
   icon: Contrast,

--- a/src/tools/csv-to-json/index.ts
+++ b/src/tools/csv-to-json/index.ts
@@ -1,10 +1,11 @@
 import { FileText } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'CSV to JSON',
+  name: translate('tools.csv-to-json.title'),
   path: '/csv-to-json',
-  description: 'Convert CSV (comma, semicolon or any delimiter) to JSON, with proper handling of quoted fields, escaped quotes and embedded newlines.',
+  description: translate('tools.csv-to-json.description'),
   keywords: ['csv', 'json', 'convert', 'converter', 'parse', 'delimiter', 'tsv', 'spreadsheet', 'table'],
   component: () => import('./csv-to-json.vue'),
   icon: FileText,

--- a/src/tools/data-storage-converter/index.ts
+++ b/src/tools/data-storage-converter/index.ts
@@ -1,10 +1,11 @@
 import { Database } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Data storage converter',
+  name: translate('tools.data-storage-converter.title'),
   path: '/data-storage-converter',
-  description: 'Convert digital storage sizes between bits, bytes and their decimal (kB, MB, GB…) and binary (KiB, MiB, GiB…) multiples.',
+  description: translate('tools.data-storage-converter.description'),
   keywords: ['data', 'storage', 'size', 'converter', 'byte', 'bit', 'kilobyte', 'megabyte', 'gigabyte', 'terabyte', 'kibibyte', 'mebibyte', 'gibibyte', 'binary', 'decimal', 'iec', 'si'],
   component: () => import('./data-storage-converter.vue'),
   icon: Database,

--- a/src/tools/duration-converter/index.ts
+++ b/src/tools/duration-converter/index.ts
@@ -1,10 +1,11 @@
 import { Hourglass } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Duration converter',
+  name: translate('tools.duration-converter.title'),
   path: '/duration-converter',
-  description: 'Convert a duration between nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days and weeks, with a human-readable breakdown.',
+  description: translate('tools.duration-converter.description'),
   keywords: ['duration', 'time', 'converter', 'nanosecond', 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day', 'week', 'humanize'],
   component: () => import('./duration-converter.vue'),
   icon: Hourglass,

--- a/src/tools/html-to-markdown/index.ts
+++ b/src/tools/html-to-markdown/index.ts
@@ -1,10 +1,11 @@
 import { Markdown } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'HTML to Markdown',
+  name: translate('tools.html-to-markdown.title'),
   path: '/html-to-markdown',
-  description: 'Convert HTML to clean Markdown, with headings, links, lists, emphasis and fenced code blocks.',
+  description: translate('tools.html-to-markdown.description'),
   keywords: ['html', 'markdown', 'md', 'convert', 'converter', 'turndown', 'transform'],
   component: () => import('./html-to-markdown.vue'),
   icon: Markdown,

--- a/src/tools/i18n-coverage.test.ts
+++ b/src/tools/i18n-coverage.test.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+// This test guards the internationalisation of the tool catalogue with an
+// auto-ratcheting floor, mirroring the unit-coverage threshold in
+// vite.config.ts. A tool counts as "internationalised" when its title and
+// description are translatable: a non-empty `tools.<name>.title` and
+// `.description` in locales/en.yml AND a matching `translate('tools.<name>.*')`
+// call in the tool's index.ts. When coverage rises above the floor, a local
+// run rewrites the floor upward so the gain is locked in; CI only ever asserts
+// against the committed floor (it never writes), so the check stays
+// deterministic there.
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const TOOLS_DIR = resolve(ROOT, 'src/tools');
+const EN_LOCALE = resolve(ROOT, 'locales/en.yml');
+const FLOOR_FILE = resolve(ROOT, 'i18n-coverage.json');
+
+function listToolKeys(): string[] {
+  return readdirSync(TOOLS_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && existsSync(resolve(TOOLS_DIR, entry.name, 'index.ts')))
+    .map(entry => entry.name)
+    .sort();
+}
+
+function hasLocaleStrings(toolsSection: Record<string, any>, key: string): boolean {
+  const block = toolsSection?.[key];
+  return Boolean(
+    block
+    && typeof block.title === 'string' && block.title.trim() !== ''
+    && typeof block.description === 'string' && block.description.trim() !== '',
+  );
+}
+
+function usesTranslate(key: string): boolean {
+  const index = readFileSync(resolve(TOOLS_DIR, key, 'index.ts'), 'utf8');
+  return index.includes(`translate('tools.${key}.title')`);
+}
+
+describe('tool i18n coverage', () => {
+  const toolKeys = listToolKeys();
+  const enLocale = parse(readFileSync(EN_LOCALE, 'utf8')) ?? {};
+  const toolsSection = enLocale.tools ?? {};
+
+  const uncovered = toolKeys.filter(key => !(hasLocaleStrings(toolsSection, key) && usesTranslate(key)));
+  const covered = toolKeys.length - uncovered.length;
+  // Floor to two decimals so the measured value never overstates coverage.
+  const coverage = Math.floor((covered / toolKeys.length) * 10000) / 100;
+
+  const floorConfig = JSON.parse(readFileSync(FLOOR_FILE, 'utf8'));
+  const floor: number = floorConfig.minCoveragePercent;
+
+  it(`keeps tool i18n coverage at or above the ${floor}% floor`, () => {
+    const message = uncovered.length > 0
+      ? `${covered}/${toolKeys.length} tools internationalised (${coverage}%). `
+      + `Missing a translate()-wired title/description in locales/en.yml:\n  - ${uncovered.join('\n  - ')}`
+      : undefined;
+
+    expect(coverage, message).toBeGreaterThanOrEqual(floor);
+
+    // Ratchet the floor upward on local runs; CI only asserts (never writes).
+    if (!process.env.CI && coverage > floor) {
+      writeFileSync(FLOOR_FILE, `${JSON.stringify({ ...floorConfig, minCoveragePercent: coverage }, null, 2)}\n`);
+    }
+  });
+});

--- a/src/tools/json-sort-keys/index.ts
+++ b/src/tools/json-sort-keys/index.ts
@@ -1,10 +1,11 @@
 import { SortAscendingLetters } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'JSON sort keys',
+  name: translate('tools.json-sort-keys.title'),
   path: '/json-sort-keys',
-  description: 'Recursively sort the keys of a JSON object to produce a canonical, diff-friendly output (array order is preserved).',
+  description: translate('tools.json-sort-keys.description'),
   keywords: ['json', 'sort', 'keys', 'order', 'canonical', 'normalize', 'diff', 'alphabetical'],
   component: () => import('./json-sort-keys.vue'),
   icon: SortAscendingLetters,

--- a/src/tools/json-to-typescript/index.ts
+++ b/src/tools/json-to-typescript/index.ts
@@ -1,10 +1,11 @@
 import { Braces } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'JSON to TypeScript',
+  name: translate('tools.json-to-typescript.title'),
   path: '/json-to-typescript',
-  description: 'Generate TypeScript interfaces from a JSON object or array, with nested types automatically extracted.',
+  description: translate('tools.json-to-typescript.description'),
   keywords: ['json', 'typescript', 'ts', 'interface', 'type', 'types', 'convert', 'generate', 'definition'],
   component: () => import('./json-to-typescript.vue'),
   icon: Braces,

--- a/src/tools/jwt-generator/index.ts
+++ b/src/tools/jwt-generator/index.ts
@@ -1,10 +1,11 @@
 import { Signature } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'JWT generator',
+  name: translate('tools.jwt-generator.title'),
   path: '/jwt-generator',
-  description: 'Sign and generate a JSON Web Token (JWT) from a payload and key - HS256/384/512, RS, PS, ES and EdDSA. Runs entirely in your browser; the key never leaves your device.',
+  description: translate('tools.jwt-generator.description'),
   keywords: ['jwt', 'generator', 'sign', 'signer', 'create', 'encode', 'token', 'hs256', 'rs256', 'es256', 'eddsa', 'json', 'web', 'token'],
   component: () => import('./jwt-generator.vue'),
   icon: Signature,

--- a/src/tools/markdown-toc-generator/index.ts
+++ b/src/tools/markdown-toc-generator/index.ts
@@ -1,10 +1,11 @@
 import { ListDetails } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Markdown TOC generator',
+  name: translate('tools.markdown-toc-generator.title'),
   path: '/markdown-toc-generator',
-  description: 'Generate a nested table of contents with GitHub-style anchor links from the headings of a Markdown document.',
+  description: translate('tools.markdown-toc-generator.description'),
   keywords: ['markdown', 'toc', 'table', 'contents', 'heading', 'anchor', 'links', 'readme', 'outline'],
   component: () => import('./markdown-toc-generator.vue'),
   icon: ListDetails,

--- a/src/tools/number-to-words/index.ts
+++ b/src/tools/number-to-words/index.ts
@@ -1,10 +1,11 @@
 import { Vocabulary } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Number to words',
+  name: translate('tools.number-to-words.title'),
   path: '/number-to-words',
-  description: 'Spell out a number in English words (e.g. 1234 becomes "one thousand two hundred thirty-four"), with support for negatives and decimals.',
+  description: translate('tools.number-to-words.description'),
   keywords: ['number', 'words', 'spell', 'english', 'text', 'convert', 'cardinal', 'humanize', 'cheque', 'check'],
   component: () => import('./number-to-words.vue'),
   icon: Vocabulary,

--- a/src/tools/string-escape/index.ts
+++ b/src/tools/string-escape/index.ts
@@ -1,10 +1,11 @@
 import { Quote } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'String escape / unescape',
+  name: translate('tools.string-escape.title'),
   path: '/string-escape',
-  description: 'Escape or unescape a string using backslash sequences (\\n, \\t, \\", \\uXXXX…), as used in JSON, JavaScript and many programming languages.',
+  description: translate('tools.string-escape.description'),
   keywords: ['string', 'escape', 'unescape', 'backslash', 'json', 'javascript', 'quote', 'newline', 'tab', 'unicode'],
   component: () => import('./string-escape.vue'),
   icon: Quote,

--- a/src/tools/text-line-tools/index.ts
+++ b/src/tools/text-line-tools/index.ts
@@ -1,10 +1,11 @@
 import { ListNumbers } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Text line tools',
+  name: translate('tools.text-line-tools.title'),
   path: '/text-line-tools',
-  description: 'Sort, deduplicate, reverse, shuffle, number, trim and filter the lines of a block of text.',
+  description: translate('tools.text-line-tools.description'),
   keywords: ['text', 'line', 'lines', 'sort', 'dedupe', 'deduplicate', 'unique', 'reverse', 'shuffle', 'number', 'trim', 'empty', 'filter'],
   component: () => import('./text-line-tools.vue'),
   icon: ListNumbers,

--- a/src/tools/unicode-inspector/index.ts
+++ b/src/tools/unicode-inspector/index.ts
@@ -1,10 +1,11 @@
 import { Typography } from '@vicons/tabler';
+import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
-  name: 'Unicode inspector',
+  name: translate('tools.unicode-inspector.title'),
   path: '/unicode-inspector',
-  description: 'Inspect a string character by character: Unicode code point, decimal value, HTML entity, and UTF-8 / UTF-16 byte sequences.',
+  description: translate('tools.unicode-inspector.description'),
   keywords: ['unicode', 'inspector', 'character', 'code point', 'codepoint', 'utf-8', 'utf-16', 'html', 'entity', 'emoji', 'hex'],
   component: () => import('./unicode-inspector.vue'),
   icon: Typography,


### PR DESCRIPTION
## Summary

Adds an auto-ratcheting **i18n coverage floor** for the tool catalogue — the same no-regression pattern used for unit coverage — and brings the 13 recently-added tools up to it.

## Changes (one commit each)

1. **`test(i18n)` i18n coverage test + ratcheting floor** — A vitest check (`src/tools/i18n-coverage.test.ts`) measures what fraction of tools are internationalised and fails when it drops below a committed floor in `i18n-coverage.json`.
   - A tool counts as internationalised when it has a **non-empty `tools.<name>.title` and `.description` in `locales/en.yml`** *and* a **`translate('tools.<name>.*')` call in its `index.ts`** (end-to-end, not just one half).
   - The floor **auto-ratchets upward on local runs** when coverage improves and is never lowered; **CI only asserts** against the committed floor (guarded by `process.env.CI`, so the check is deterministic there and never depends on a self-modifying file) — mirroring the unit-coverage `autoUpdate` in `vite.config.ts`.
   - On failure it prints the exact list of tools missing translations.
   - Floor starts at the current **70%** (70/100 tools — notably, 17 of the gaps are pre-existing tools, not new ones).

2. **`i18n` internationalise the 13 recent tools** — Moves the `title`/`description` of the JWT generator, color contrast checker, data storage converter, text line tools, JSON→TypeScript, CSV→JSON, duration converter, HTML→Markdown, string escape/unescape, number to words, Unicode inspector, Markdown TOC generator and JSON sort keys into `locales/en.yml`, and wires their `index.ts` through `translate()`. This raises coverage **70% → 83%**, and the floor is ratcheted to match.

Follow-up PRs can chip the remaining 17 pre-existing untranslated tools toward 100%; the ratchet makes that incremental work safe, and from now on **any new tool added without translations fails CI** (it would drop the ratio below the floor).

## Testing

- `pnpm test` — green; the new i18n test passes at the 83% floor
- Verified the failure path: raising the floor above actual coverage fails and lists the uncovered tools
- Verified the CI guard: with `CI=true` the floor file is not rewritten
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm coverage` — unit-coverage floor unchanged
- `pnpm build` — succeeds
- Re-ran the e2e for all 13 tools in real Chromium — all green (their `toHaveTitle(...)` assertions confirm `translate()` resolves to the correct English strings, not raw keys), plus a screenshot check of a translated tool page

## Notes

- English-only entries are added; other locales fall back to English automatically per the repo's i18n convention.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_