### PR TITLE
chore(tracking): remove leftover tracking references

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,8 +2,6 @@
 /// <reference types="vite-svg-loader" />
 
 interface ImportMetaEnv {
-  VITE_PLAUSIBLE_API_HOST: string;
-  VITE_PLAUSIBLE_DOMAIN: string;
   PACKAGE_VERSION: string;
   GIT_SHORT_SHA: string;
   PROD: boolean;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="favicon.ico" />
-    <div class="cf-turnstile" data-sitekey="0x4AAAAAAAU7yTi8qdIUvNly" data-callback="javascriptCallback"></div>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IT Tools - Handy online tools for developers</title>
     <meta itemprop="name" content="IT Tools - Handy online tools for developers" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
         description: 'Aggregated set of useful tools for developers.',
         display: 'standalone',
         lang: 'fr-FR',
-        start_url: `${baseUrl}?utm_source=pwa&utm_medium=pwa`,
+        start_url: baseUrl,
         orientation: 'any',
         theme_color: '#18a058',
         background_color: '#f1f5f9',


### PR DESCRIPTION
## Summary

A tracking-removal audit of the whole repo. The **active** tracking was already removed earlier (`feat(security): remove Plausible + Google tracking and tighten the CSP`); this cleans up the three dead leftovers the audit surfaced.

## Audit result

**Confirmed clean (no action needed):**
- No analytics/ads plugin, no wiring in `main.ts`, `App.vue`, `router.ts`, or any store (no pageview/`track()` hooks).
- No `index.html` script tags for analytics/ads; no `.env` files defining tracking vars.
- CSP configs (`vercel.json`, `netlify.toml`, `public/_headers`, `docker/`, `worker/`) contain **no** analytics/ad/utm domains.
- `workbox-google-analytics` appears in the lockfile as an inert transitive dep only — the PWA config does **not** enable `offlineGoogleAnalytics`, the generated `sw.js` has zero GA references, and the single hit in the workbox chunk is just a cache-name string constant (`{googleAnalytics:"googleAnalytics", …}`), never invoked.

**Removed in this PR (dead leftovers):**
1. **`env.d.ts`** — the unused `VITE_PLAUSIBLE_API_HOST` / `VITE_PLAUSIBLE_DOMAIN` type declarations. Nothing in `src/` reads them; the Plausible integration itself was already gone.
2. **`index.html`** — an orphaned Cloudflare **Turnstile** `<div>` sitting inside `<head>` (invalid placement) with `data-callback="javascriptCallback"` but **no loader script and no such callback defined**. It rendered nothing and issued no request — pure dead markup. (Flagging explicitly: if bot protection is ever wanted, it would need to be added properly with the api.js loader; the current markup was non-functional.)
3. **`vite.config.ts`** — the `?utm_source=pwa&utm_medium=pwa` campaign parameters on the PWA manifest `start_url`. UTM params exist solely to attribute traffic in analytics; with no analytics they do nothing. `start_url` is now the plain base URL.

## Testing

- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm build` — succeeds; verified the built `index.html` no longer contains the Turnstile div and `manifest.webmanifest` `start_url` is now `/`

No functional change — the app already shipped no analytics or ads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_