### PR TITLE
feat(case-converter): add Pascal_Snake_Case and internationalise two tools

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -269,6 +269,12 @@ tools:
   qrcode-generator:
     title: QR Code generator
     description: Generate and download a QR code for a URL (or just plain text), and customize the background and foreground colors.
+    text: 'Text:'
+    textPlaceholder: Your link or text...
+    foregroundColor: 'Foreground color:'
+    backgroundColor: 'Background color:'
+    errorResistance: 'Error resistance:'
+    download: Download qr-code
 
   wifi-qrcode-generator:
     title: WiFi QR Code generator

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -220,6 +220,23 @@ tools:
   case-converter:
     title: Case converter
     description: Transform the case of a string and choose between different formats
+    yourString: 'Your string:'
+    placeholder: Your string...
+    lowercase: 'Lowercase:'
+    uppercase: 'Uppercase:'
+    camelcase: 'Camelcase:'
+    capitalcase: 'Capitalcase:'
+    constantcase: 'Constantcase:'
+    dotcase: 'Dotcase:'
+    traincase: 'Traincase:'
+    nocase: 'Nocase:'
+    kebabcase: 'Kebabcase:'
+    pascalcase: 'Pascalcase:'
+    pascalsnakecase: 'Pascal snake case:'
+    pathcase: 'Pathcase:'
+    sentencecase: 'Sentencecase:'
+    snakecase: 'Snakecase:'
+    mockingcase: 'Mockingcase:'
 
   html-entities:
     title: Escape HTML entities

--- a/src/tools/case-converter/case-converter.service.test.ts
+++ b/src/tools/case-converter/case-converter.service.test.ts
@@ -9,6 +9,7 @@ import {
   toMockingCase,
   toNoCase,
   toPascalCase,
+  toPascalSnakeCase,
   toPathCase,
   toSentenceCase,
   toSnakeCase,
@@ -174,6 +175,20 @@ describe('case-converter', () => {
 
     it('handles an empty string', () => {
       expect(toPascalCase('')).toBe('');
+    });
+  });
+
+  describe('toPascalSnakeCase', () => {
+    it('converts a sentence to Pascal_Snake_Case', () => {
+      expect(toPascalSnakeCase('lorem ipsum dolor sit amet')).toBe('Lorem_Ipsum_Dolor_Sit_Amet');
+    });
+
+    it('handles mixed delimiters', () => {
+      expect(toPascalSnakeCase('hello-world_foo bar')).toBe('Hello_World_Foo_Bar');
+    });
+
+    it('handles an empty string', () => {
+      expect(toPascalSnakeCase('')).toBe('');
     });
   });
 

--- a/src/tools/case-converter/case-converter.service.ts
+++ b/src/tools/case-converter/case-converter.service.ts
@@ -6,6 +6,7 @@ import {
   kebabCase,
   noCase,
   pascalCase,
+  pascalSnakeCase,
   pathCase,
   sentenceCase,
   snakeCase,
@@ -22,6 +23,7 @@ export {
   toMockingCase,
   toNoCase,
   toPascalCase,
+  toPascalSnakeCase,
   toPathCase,
   toSentenceCase,
   toSnakeCase,
@@ -67,6 +69,10 @@ function toKebabCase(input: string): string {
 
 function toPascalCase(input: string): string {
   return pascalCase(input);
+}
+
+function toPascalSnakeCase(input: string): string {
+  return pascalSnakeCase(input);
 }
 
 function toPathCase(input: string): string {

--- a/src/tools/case-converter/case-converter.vue
+++ b/src/tools/case-converter/case-converter.vue
@@ -10,6 +10,7 @@ import {
   toMockingCase,
   toNoCase,
   toPascalCase,
+  toPascalSnakeCase,
   toPathCase,
   toSentenceCase,
   toSnakeCase,
@@ -17,63 +18,69 @@ import {
   toUpperCase,
 } from './case-converter.service';
 
+const { t } = useI18n();
+
 const input = ref('lorem ipsum dolor sit amet');
 
 const formats = computed(() => [
   {
-    label: 'Lowercase:',
+    label: t('tools.case-converter.lowercase'),
     value: toLowerCase(input.value),
   },
   {
-    label: 'Uppercase:',
+    label: t('tools.case-converter.uppercase'),
     value: toUpperCase(input.value),
   },
   {
-    label: 'Camelcase:',
+    label: t('tools.case-converter.camelcase'),
     value: toCamelCase(input.value),
   },
   {
-    label: 'Capitalcase:',
+    label: t('tools.case-converter.capitalcase'),
     value: toCapitalCase(input.value),
   },
   {
-    label: 'Constantcase:',
+    label: t('tools.case-converter.constantcase'),
     value: toConstantCase(input.value),
   },
   {
-    label: 'Dotcase:',
+    label: t('tools.case-converter.dotcase'),
     value: toDotCase(input.value),
   },
   {
-    label: 'Traincase:',
+    label: t('tools.case-converter.traincase'),
     value: toTrainCase(input.value),
   },
   {
-    label: 'Nocase:',
+    label: t('tools.case-converter.nocase'),
     value: toNoCase(input.value),
   },
   {
-    label: 'Kebabcase:',
+    label: t('tools.case-converter.kebabcase'),
     value: toKebabCase(input.value),
   },
   {
-    label: 'Pascalcase:',
+    label: t('tools.case-converter.pascalcase'),
     value: toPascalCase(input.value),
   },
   {
-    label: 'Pathcase:',
+    label: t('tools.case-converter.pascalsnakecase'),
+    value: toPascalSnakeCase(input.value),
+  },
+  {
+    label: t('tools.case-converter.pathcase'),
     value: toPathCase(input.value),
   },
   {
-    label: 'Sentencecase:',
+    label: t('tools.case-converter.sentencecase'),
     value: toSentenceCase(input.value),
   },
   {
-    label: 'Snakecase:',
+    label: t('tools.case-converter.snakecase'),
     value: toSnakeCase(input.value),
   },
   {
-    label: 'Mockingcase:',
+    label: t('tools.case-converter.mockingcase'),
     value: toMockingCase(input.value),
   },
 ]);
@@ -89,8 +96,8 @@ const inputLabelAlignmentConfig = {
   <c-card>
     <c-input-text
       v-model:value="input"
-      label="Your string:"
-      placeholder="Your string..."
+      :label="t('tools.case-converter.yourString')"
+      :placeholder="t('tools.case-converter.placeholder')"
       raw-text
       v-bind="inputLabelAlignmentConfig"
     />

--- a/src/tools/qr-code-generator/qr-code-generator.vue
+++ b/src/tools/qr-code-generator/qr-code-generator.vue
@@ -3,6 +3,8 @@ import type { QRCodeErrorCorrectionLevel } from 'qrcode';
 import { useDownloadFileFromBase64 } from '@/composable/downloadBase64';
 import { useQRCode } from './useQRCode';
 
+const { t } = useI18n();
+
 const foreground = ref('#000000ff');
 const background = ref('#ffffffff');
 const errorCorrectionLevel = ref<QRCodeErrorCorrectionLevel>('medium');
@@ -32,23 +34,23 @@ const { download } = useDownloadFileFromBase64({ source: qrcode, filename: 'qr-c
           label-position="left"
           label-width="130px"
           label-align="right"
-          label="Text:"
+          :label="t('tools.qrcode-generator.text')"
           multiline
           rows="1"
           autosize
-          placeholder="Your link or text..."
+          :placeholder="t('tools.qrcode-generator.textPlaceholder')"
           mb-6
         />
         <n-form label-width="130" label-placement="left">
-          <n-form-item label="Foreground color:">
+          <n-form-item :label="t('tools.qrcode-generator.foregroundColor')">
             <n-color-picker v-model:value="foreground" :modes="['hex']" />
           </n-form-item>
-          <n-form-item label="Background color:">
+          <n-form-item :label="t('tools.qrcode-generator.backgroundColor')">
             <n-color-picker v-model:value="background" :modes="['hex']" />
           </n-form-item>
           <c-select
             v-model:value="errorCorrectionLevel"
-            label="Error resistance:"
+            :label="t('tools.qrcode-generator.errorResistance')"
             label-position="left"
             label-width="130px"
             label-align="right"
@@ -60,7 +62,7 @@ const { download } = useDownloadFileFromBase64({ source: qrcode, filename: 'qr-c
         <div flex flex-col items-center gap-3>
           <n-image :src="qrcode" width="200" />
           <c-button @click="download">
-            Download qr-code
+            {{ t('tools.qrcode-generator.download') }}
           </c-button>
         </div>
       </n-gi>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -173,9 +173,9 @@ export default defineConfig({
       // get locked in as the new floor. Commit the bumped values.
       thresholds: {
         autoUpdate: true,
-        lines: 69.31,
-        statements: 69.9,
-        functions: 68.1,
+        lines: 69.33,
+        statements: 69.91,
+        functions: 68.15,
         branches: 77.34,
       },
     },


### PR DESCRIPTION
## Summary

Another round of the "improve existing tools + i18n" work: a new case format for the case converter, plus internationalising the in-tool UI of two more tools (case converter and QR code generator).

## Changes (one commit each)

1. **`feat(case-converter)` add Pascal_Snake_Case** — `change-case` already provides `pascalSnakeCase` but the tool didn't expose it; adds a `toPascalSnakeCase` transform (with a unit test) so users can convert to `Pascal_Snake_Case` alongside the existing 14 formats.

2. **`i18n(case-converter)` internationalise the in-tool UI** — Moves the input label/placeholder and every case-format label into `locales/en.yml` and wires the component through `useI18n()`.

3. **`i18n(qr-code-generator)` internationalise the in-tool UI** — Moves the text label/placeholder, the foreground/background colour labels, the error-resistance label, and the download button text into `locales/en.yml`.

4. **`chore(coverage)` ratchet thresholds** — `autoUpdate` bumped the lines/statements/functions floors up after the new Pascal_Snake_Case test.

## Testing

- `pnpm test` — green (case-converter suite now 52 tests incl. Pascal_Snake_Case)
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm coverage` — passes; thresholds ratcheted up
- `pnpm build` — succeeds
- i18n coverage test stays at 100%
- Verified both tools in a real browser: the case converter shows the new **Pascal snake case** row (`Lorem_Ipsum_Dolor_Sit_Amet`) with all labels translated, and the QR generator renders with all labels translated

## Notes

- English-only locale entries added; other locales fall back to English per the repo convention. No new dependencies (`change-case` already provides `pascalSnakeCase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_