### PR TITLE
feat(slugify-string): add separator/lowercase options and internationalise four tools

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -164,6 +164,9 @@ tools:
   random-port-generator:
     title: Random port generator
     description: Generate random port numbers outside of the range of "known" ports (0-1023).
+    copy: Copy
+    refresh: Refresh
+    copied: Port copied to the clipboard
 
   yaml-prettify:
     title: YAML prettify and format
@@ -439,6 +442,13 @@ tools:
   basic-auth-generator:
     title: Basic auth generator
     description: Generate a base64 basic auth header from a username and password.
+    username: Username
+    usernamePlaceholder: Your username...
+    password: Password
+    passwordPlaceholder: Your password...
+    header: 'Authorization header:'
+    copyHeader: Copy header
+    copied: Header copied to the clipboard
 
   text-to-unicode:
     title: Text to Unicode

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -315,6 +315,17 @@ tools:
   mac-address-generator:
     title: MAC address generator
     description: Enter the quantity and prefix. MAC addresses will be generated in your chosen case (uppercase or lowercase)
+    quantity: 'Quantity:'
+    prefix: 'MAC address prefix:'
+    prefixPlaceholder: 'Set a prefix, e.g. 64:16:7F'
+    case: 'Case:'
+    uppercase: Uppercase
+    lowercase: Lowercase
+    separator: 'Separator:'
+    separatorNone: None
+    refresh: Refresh
+    copy: Copy
+    copied: MAC addresses copied to the clipboard
 
   json-diff:
     title: JSON diff

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -148,6 +148,14 @@ tools:
   slugify-string:
     title: Slugify string
     description: Make a string url, filename and id safe.
+    yourString: Your string to slugify
+    stringPlaceholder: 'Put your string here (ex: My file path)'
+    yourSlug: Your slug
+    slugPlaceholder: 'Your slug will be generated here (ex: my-file-path)'
+    separator: 'Separator:'
+    lowercase: 'Lowercase:'
+    copySlug: Copy slug
+    copied: Slug copied to clipboard
 
   encryption:
     title: Encrypt / decrypt text

--- a/src/tools/basic-auth-generator/basic-auth-generator.vue
+++ b/src/tools/basic-auth-generator/basic-auth-generator.vue
@@ -2,20 +2,22 @@
 import { useCopy } from '@/composable/copy';
 import { getBasicAuthHeader } from './basic-auth-generator.service';
 
+const { t } = useI18n();
+
 const username = ref('');
 const password = ref('');
 const header = computed(() => getBasicAuthHeader({ username: username.value, password: password.value }));
 
-const { copy } = useCopy({ source: header, text: 'Header copied to the clipboard' });
+const { copy } = useCopy({ source: header, text: t('tools.basic-auth-generator.copied') });
 </script>
 
 <template>
   <div>
-    <c-input-text v-model:value="username" label="Username" placeholder="Your username..." clearable raw-text mb-5 />
+    <c-input-text v-model:value="username" :label="t('tools.basic-auth-generator.username')" :placeholder="t('tools.basic-auth-generator.usernamePlaceholder')" clearable raw-text mb-5 />
     <c-input-text
       v-model:value="password"
-      label="Password"
-      placeholder="Your password..."
+      :label="t('tools.basic-auth-generator.password')"
+      :placeholder="t('tools.basic-auth-generator.passwordPlaceholder')"
       clearable
       raw-text
       mb-2
@@ -23,7 +25,7 @@ const { copy } = useCopy({ source: header, text: 'Header copied to the clipboard
     />
 
     <c-card>
-      <n-statistic label="Authorization header:" class="header">
+      <n-statistic :label="t('tools.basic-auth-generator.header')" class="header">
         <n-scrollbar x-scrollable style="max-width: 550px; margin-bottom: -10px; padding-bottom: 10px" trigger="none">
           {{ header }}
         </n-scrollbar>
@@ -31,7 +33,7 @@ const { copy } = useCopy({ source: header, text: 'Header copied to the clipboard
     </c-card>
     <div mt-5 flex justify-center>
       <c-button @click="copy()">
-        Copy header
+        {{ t('tools.basic-auth-generator.copyHeader') }}
       </c-button>
     </div>
   </div>

--- a/src/tools/mac-address-generator/mac-address-generator.vue
+++ b/src/tools/mac-address-generator/mac-address-generator.vue
@@ -5,18 +5,20 @@ import { useCopy } from '@/composable/copy';
 import { usePartialMacAddressValidation } from '@/utils/macAddress';
 import { generateRandomMacAddress } from './mac-adress-generator.models';
 
+const { t } = useI18n();
+
 const amount = useStorage('mac-address-generator-amount', 1);
 const macAddressPrefix = useStorage('mac-address-generator-prefix', '64:16:7F');
 
 const prefixValidation = usePartialMacAddressValidation(macAddressPrefix);
 
-const casesTransformers = [
-  { label: 'Uppercase', value: (value: string) => value.toUpperCase() },
-  { label: 'Lowercase', value: (value: string) => value.toLowerCase() },
-];
-const caseTransformer = ref(casesTransformers[0]?.value ?? ((value: string) => value.toUpperCase()));
+const casesTransformers = computed(() => [
+  { label: t('tools.mac-address-generator.uppercase'), value: (value: string) => value.toUpperCase() },
+  { label: t('tools.mac-address-generator.lowercase'), value: (value: string) => value.toLowerCase() },
+]);
+const caseTransformer = ref(casesTransformers.value[0]?.value ?? ((value: string) => value.toUpperCase()));
 
-const separators = [
+const separators = computed(() => [
   {
     label: ':',
     value: ':',
@@ -30,11 +32,11 @@ const separators = [
     value: '.',
   },
   {
-    label: 'None',
+    label: t('tools.mac-address-generator.separatorNone'),
     value: '',
   },
-];
-const separator = useStorage('mac-address-generator-separator', separators[0]?.value ?? ':');
+]);
+const separator = useStorage('mac-address-generator-separator', separators.value[0]?.value ?? ':');
 
 const [macAddresses, refreshMacAddresses] = computedRefreshable(() => {
   if (!prefixValidation.isValid) {
@@ -48,20 +50,20 @@ const [macAddresses, refreshMacAddresses] = computedRefreshable(() => {
   return ids.join('\n');
 });
 
-const { copy } = useCopy({ source: macAddresses, text: 'MAC addresses copied to the clipboard' });
+const { copy } = useCopy({ source: macAddresses, text: t('tools.mac-address-generator.copied') });
 </script>
 
 <template>
   <div flex flex-col justify-center gap-2>
     <div flex items-center>
-      <label w-150px pr-12px text-right> Quantity:</label>
+      <label w-150px pr-12px text-right> {{ t('tools.mac-address-generator.quantity') }}</label>
       <n-input-number v-model:value="amount" min="1" max="100" flex-1 />
     </div>
 
     <c-input-text
       v-model:value="macAddressPrefix"
-      label="MAC address prefix:"
-      placeholder="Set a prefix, e.g. 64:16:7F"
+      :label="t('tools.mac-address-generator.prefix')"
+      :placeholder="t('tools.mac-address-generator.prefixPlaceholder')"
       clearable
       label-position="left"
       spellcheck="false"
@@ -74,7 +76,7 @@ const { copy } = useCopy({ source: macAddresses, text: 'MAC addresses copied to 
     <c-buttons-select
       v-model:value="caseTransformer"
       :options="casesTransformers"
-      label="Case:"
+      :label="t('tools.mac-address-generator.case')"
       label-width="150px"
       label-align="right"
     />
@@ -82,7 +84,7 @@ const { copy } = useCopy({ source: macAddresses, text: 'MAC addresses copied to 
     <c-buttons-select
       v-model:value="separator"
       :options="separators"
-      label="Separator:"
+      :label="t('tools.mac-address-generator.separator')"
       label-width="150px"
       label-align="right"
     />
@@ -93,10 +95,10 @@ const { copy } = useCopy({ source: macAddresses, text: 'MAC addresses copied to 
 
     <div flex justify-center gap-2>
       <c-button data-test-id="refresh" @click="refreshMacAddresses()">
-        Refresh
+        {{ t('tools.mac-address-generator.refresh') }}
       </c-button>
       <c-button @click="copy()">
-        Copy
+        {{ t('tools.mac-address-generator.copy') }}
       </c-button>
     </div>
   </div>

--- a/src/tools/random-port-generator/random-port-generator.vue
+++ b/src/tools/random-port-generator/random-port-generator.vue
@@ -3,9 +3,11 @@ import { computedRefreshable } from '@/composable/computedRefreshable';
 import { useCopy } from '@/composable/copy';
 import { generatePort } from './random-port-generator.service';
 
+const { t } = useI18n();
+
 const [port, refreshPort] = computedRefreshable(() => String(generatePort()));
 
-const { copy } = useCopy({ source: port, text: 'Port copied to the clipboard' });
+const { copy } = useCopy({ source: port, text: t('tools.random-port-generator.copied') });
 </script>
 
 <template>
@@ -15,10 +17,10 @@ const { copy } = useCopy({ source: port, text: 'Port copied to the clipboard' })
     </div>
     <div flex justify-center gap-3>
       <c-button @click="copy()">
-        Copy
+        {{ t('tools.random-port-generator.copy') }}
       </c-button>
       <c-button @click="refreshPort">
-        Refresh
+        {{ t('tools.random-port-generator.refresh') }}
       </c-button>
     </div>
   </c-card>

--- a/src/tools/slugify-string/slugify-string.service.test.ts
+++ b/src/tools/slugify-string/slugify-string.service.test.ts
@@ -45,5 +45,14 @@ describe('slugify-string', () => {
     it('handles a string with only special characters', () => {
       expect(slugifyString('!@#$%')).toBe('');
     });
+
+    it('supports a custom separator', () => {
+      expect(slugifyString('My file path', { separator: '_' })).toBe('my_file_path');
+      expect(slugifyString('My file path', { separator: '.' })).toBe('my.file.path');
+    });
+
+    it('can preserve the original case', () => {
+      expect(slugifyString('My File Path', { lowercase: false })).toBe('My-File-Path');
+    });
   });
 });

--- a/src/tools/slugify-string/slugify-string.service.ts
+++ b/src/tools/slugify-string/slugify-string.service.ts
@@ -2,6 +2,9 @@ import slugify from '@sindresorhus/slugify';
 
 export { slugifyString };
 
-function slugifyString(input: string): string {
-  return slugify(input);
+function slugifyString(
+  input: string,
+  { separator = '-', lowercase = true }: { separator?: string; lowercase?: boolean } = {},
+): string {
+  return slugify(input, { separator, lowercase });
 }

--- a/src/tools/slugify-string/slugify-string.vue
+++ b/src/tools/slugify-string/slugify-string.vue
@@ -3,20 +3,55 @@ import { useCopy } from '@/composable/copy';
 import { withDefaultOnError } from '@/utils/defaults';
 import { slugifyString } from './slugify-string.service';
 
+const { t } = useI18n();
+
 const input = ref('');
-const slug = computed(() => withDefaultOnError(() => slugifyString(input.value), ''));
-const { copy } = useCopy({ source: slug, text: 'Slug copied to clipboard' });
+const separator = ref('-');
+const lowercase = ref(true);
+
+const slug = computed(() =>
+  withDefaultOnError(() => slugifyString(input.value, { separator: separator.value, lowercase: lowercase.value }), ''),
+);
+const { copy } = useCopy({ source: slug, text: t('tools.slugify-string.copied') });
 </script>
 
 <template>
   <div>
-    <c-input-text v-model:value="input" multiline placeholder="Put your string here (ex: My file path)" label="Your string to slugify" autofocus raw-text mb-5 />
+    <c-input-text
+      v-model:value="input"
+      multiline
+      :placeholder="t('tools.slugify-string.stringPlaceholder')"
+      :label="t('tools.slugify-string.yourString')"
+      autofocus
+      raw-text
+      mb-5
+    />
 
-    <c-input-text :value="slug" multiline readonly placeholder="You slug will be generated here (ex: my-file-path)" label="Your slug" mb-5 />
+    <div mb-5 flex flex-wrap items-center gap-4>
+      <c-input-text
+        v-model:value="separator"
+        :label="t('tools.slugify-string.separator')"
+        label-position="left"
+        raw-text
+        w-40
+      />
+      <n-form-item :label="t('tools.slugify-string.lowercase')" :show-feedback="false" label-placement="left">
+        <n-switch v-model:value="lowercase" />
+      </n-form-item>
+    </div>
+
+    <c-input-text
+      :value="slug"
+      multiline
+      readonly
+      :placeholder="t('tools.slugify-string.slugPlaceholder')"
+      :label="t('tools.slugify-string.yourSlug')"
+      mb-5
+    />
 
     <div flex justify-center>
       <c-button :disabled="slug.length === 0" @click="copy()">
-        Copy slug
+        {{ t('tools.slugify-string.copySlug') }}
       </c-button>
     </div>
   </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -176,7 +176,7 @@ export default defineConfig({
         lines: 69.33,
         statements: 69.91,
         functions: 68.15,
-        branches: 77.34,
+        branches: 77.42,
       },
     },
   },


### PR DESCRIPTION
## Summary

An i18n sweep across four more tools, paired with a functional improvement to the slugify tool.

## Changes (one commit each)

1. **`feat(slugify-string)` add separator + lowercase options + i18n** — `slugifyString` now takes an optional **separator** (default `-`) and a **lowercase** toggle (default `true`), surfaced in the UI as a separator field and a switch, so users can produce e.g. `snake_case` slugs or case-preserving slugs. The tool's UI strings are internationalised in the same commit. Adds unit tests for the new options.

2. **`i18n(mac-address-generator)`** — Internationalise the quantity/prefix/case/separator labels, the uppercase/lowercase and "None" option labels, the prefix placeholder, the copy/refresh buttons, and the copy toast.

3. **`i18n(basic-auth-generator, random-port-generator)`** — Internationalise the username/password labels+placeholders, the authorization-header label and copy button, and the random-port copy/refresh buttons.

4. **`chore(coverage)` ratchet thresholds** — branch floor back up to 77.42% from the new slugify option tests.

## Testing

- `pnpm test` — all green (864 tests)
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm coverage` — passes; thresholds ratcheted up
- `pnpm build` — succeeds
- i18n coverage test stays at 100%
- Verified all four tools in a real browser: slugify shows the new **Separator** field + **Lowercase** toggle producing correct slugs, and mac-address / basic-auth / random-port render with all labels translated

## Notes

- English-only locale entries added; other locales fall back to English per the repo convention. No new dependencies (`@sindresorhus/slugify` already supports these options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_