### PR TITLE
chore(i18n): internationalise the FormatTransformer converter tools (16 tools + shared component)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -57,6 +57,9 @@ toolCard:
   new: New
 search:
   label: Search
+formatTransformer:
+  importFile: Import file
+  download: Download
 tools:
   categories:
     favorite-tools: 'Your favorite tools'
@@ -104,6 +107,9 @@ tools:
   json-to-csv:
     title: JSON to CSV
     description: Convert JSON to CSV with automatic header detection.
+    inputLabel: 'Your raw JSON'
+    inputPlaceholder: 'Paste your raw JSON here...'
+    outputLabel: 'CSV version of your JSON'
 
   camera-recorder:
     title: Camera recorder
@@ -195,6 +201,9 @@ tools:
   list-converter:
     title: List converter
     description: This tool can process column-based data and apply various changes (transpose, add prefix and suffix, reverse list, sort list, lowercase values, truncate values) to each row.
+    inputLabel: 'Your input data'
+    inputPlaceholder: 'Paste your input data here...'
+    outputLabel: 'Your transformed data'
 
   base64-string-converter:
     title: Base64 string encoder/decoder
@@ -203,6 +212,9 @@ tools:
   toml-to-yaml:
     title: TOML to YAML
     description: Parse and convert TOML to YAML.
+    inputLabel: 'Your TOML'
+    inputPlaceholder: 'Paste your TOML here...'
+    outputLabel: 'YAML from your TOML'
 
   math-evaluator:
     title: Math evaluator
@@ -211,6 +223,9 @@ tools:
   json-to-yaml-converter:
     title: JSON to YAML converter
     description: Simply convert JSON to YAML with this online live converter.
+    inputLabel: 'Your JSON'
+    inputPlaceholder: 'Paste your JSON here...'
+    outputLabel: 'YAML from your JSON'
 
   url-parser:
     title: URL parser
@@ -272,6 +287,9 @@ tools:
   toml-to-json:
     title: TOML to JSON
     description: Parse and convert TOML to JSON.
+    inputLabel: 'Your TOML'
+    inputPlaceholder: 'Paste your TOML here...'
+    outputLabel: 'JSON from your TOML'
 
   lorem-ipsum-generator:
     title: Lorem ipsum generator
@@ -294,6 +312,9 @@ tools:
   xml-formatter:
     title: XML formatter
     description: Prettify your XML string into a friendly, human-readable format.
+    inputLabel: 'Your XML'
+    inputPlaceholder: 'Paste your XML here...'
+    outputLabel: 'Formatted XML from your XML'
 
   temperature-converter:
     title: Temperature converter
@@ -314,6 +335,9 @@ tools:
   yaml-to-toml:
     title: YAML to TOML
     description: Parse and convert YAML to TOML.
+    inputLabel: 'Your YAML'
+    inputPlaceholder: 'Paste your YAML here...'
+    outputLabel: 'TOML from your YAML'
 
   mac-address-generator:
     title: MAC address generator
@@ -365,6 +389,9 @@ tools:
   json-to-toml:
     title: JSON to TOML
     description: Parse and convert JSON to TOML.
+    inputLabel: 'Your JSON'
+    inputPlaceholder: 'Paste your JSON here...'
+    outputLabel: 'TOML from your JSON'
 
   device-information:
     title: Device information
@@ -377,6 +404,9 @@ tools:
   json-minify:
     title: JSON minify
     description: Minify and compress your JSON by removing unnecessary whitespace.
+    inputLabel: 'Your raw JSON'
+    inputPlaceholder: 'Paste your raw JSON here...'
+    outputLabel: 'Minified version of your JSON'
 
   ulid-generator:
     title: ULID generator
@@ -409,6 +439,9 @@ tools:
   yaml-to-json-converter:
     title: YAML to JSON converter
     description: Simply convert YAML to JSON with this online live converter.
+    inputLabel: 'Your YAML'
+    inputPlaceholder: 'Paste your yaml here...'
+    outputLabel: 'JSON from your YAML'
 
   uuid-generator:
     title: UUIDs generator
@@ -493,10 +526,19 @@ tools:
   json-to-typescript:
     title: JSON to TypeScript
     description: 'Generate TypeScript interfaces from a JSON object or array, with nested types automatically extracted.'
+    inputLabel: 'Your JSON'
+    inputPlaceholder: 'Paste your JSON here...'
+    outputLabel: 'TypeScript interfaces'
 
   csv-to-json:
     title: CSV to JSON
     description: 'Convert CSV (comma, semicolon or any delimiter) to JSON, with proper handling of quoted fields, escaped quotes and embedded newlines.'
+    inputLabel: 'Your CSV'
+    inputPlaceholder: 'Paste your CSV here...'
+    outputLabel: 'JSON from your CSV'
+    delimiter: Delimiter
+    delimiterPlaceholder: ','
+    header: First row is a header
 
   duration-converter:
     title: Duration converter
@@ -505,6 +547,9 @@ tools:
   html-to-markdown:
     title: HTML to Markdown
     description: 'Convert HTML to clean Markdown, with headings, links, lists, emphasis and fenced code blocks.'
+    inputLabel: 'Your HTML'
+    inputPlaceholder: 'Paste your HTML here...'
+    outputLabel: 'Markdown from your HTML'
 
   string-escape:
     title: String escape / unescape
@@ -525,6 +570,12 @@ tools:
   json-sort-keys:
     title: JSON sort keys
     description: 'Recursively sort the keys of a JSON object to produce a canonical, diff-friendly output (array order is preserved).'
+    inputLabel: 'Your JSON'
+    inputPlaceholder: 'Paste your JSON here...'
+    outputLabel: 'JSON with sorted keys'
+    keyOrder: Key order
+    ascending: Ascending (A→Z)
+    descending: Descending (Z→A)
 
   ascii-text-drawer:
     title: ASCII Art Text Generator
@@ -537,6 +588,9 @@ tools:
   json-to-xml:
     title: JSON to XML
     description: 'Convert JSON to XML'
+    inputLabel: 'Your JSON content'
+    inputPlaceholder: 'Paste your JSON content here...'
+    outputLabel: 'Converted XML'
 
   markdown-to-html:
     title: Markdown to HTML
@@ -561,3 +615,6 @@ tools:
   xml-to-json:
     title: XML to JSON
     description: 'Convert XML to JSON'
+    inputLabel: 'Your XML content'
+    inputPlaceholder: 'Paste your XML content here...'
+    outputLabel: 'Converted JSON'

--- a/src/components/FormatTransformer.vue
+++ b/src/components/FormatTransformer.vue
@@ -30,6 +30,8 @@ const props = withDefaults(
   },
 );
 
+const { t } = useI18n();
+
 const {
   transformer,
   inputValidationRules,
@@ -80,7 +82,7 @@ function downloadOutput() {
     <div v-if="showImport" mb-2 flex justify-end>
       <input ref="fileInput" type="file" class="hidden" @change="onFileImport">
       <c-button size="small" @click="triggerImport">
-        Import file
+        {{ t('formatTransformer.importFile') }}
       </c-button>
     </div>
 
@@ -103,7 +105,7 @@ function downloadOutput() {
     <div mb-5px flex items-center justify-between gap-2>
       <span>{{ outputLabel }}</span>
       <c-button v-if="showDownload" size="small" :disabled="output === ''" @click="downloadOutput">
-        Download
+        {{ t('formatTransformer.download') }}
       </c-button>
     </div>
     <textarea-copyable :value="output" :language="outputLanguage" :follow-height-of="inputElement?.inputWrapperRef" />

--- a/src/tools/csv-to-json/csv-to-json.vue
+++ b/src/tools/csv-to-json/csv-to-json.vue
@@ -4,6 +4,8 @@ import { isNotThrowing } from '@/utils/boolean';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertCsvToJson } from './csv-to-json.service';
 
+const { t } = useI18n();
+
 const delimiter = ref(',');
 const useHeader = ref(true);
 
@@ -25,19 +27,19 @@ const rules = computed<UseValidationRule<string>[]>(() => [
     <div mb-2 flex flex-wrap items-center gap-4>
       <c-input-text
         v-model:value="delimiter"
-        label="Delimiter"
-        placeholder=","
+        :label="t('tools.csv-to-json.delimiter')"
+        :placeholder="t('tools.csv-to-json.delimiterPlaceholder')"
         w-24
       />
-      <n-form-item label="First row is a header" :show-feedback="false" label-placement="left">
+      <n-form-item :label="t('tools.csv-to-json.header')" :show-feedback="false" label-placement="left">
         <n-switch v-model:value="useHeader" />
       </n-form-item>
     </div>
 
     <format-transformer
-      input-label="Your CSV"
-      input-placeholder="Paste your CSV here..."
-      output-label="JSON from your CSV"
+      :input-label="t('tools.csv-to-json.inputLabel')"
+      :input-placeholder="t('tools.csv-to-json.inputPlaceholder')"
+      :output-label="t('tools.csv-to-json.outputLabel')"
       output-language="json"
       download-file-name="data.json"
       :input-validation-rules="rules"

--- a/src/tools/html-to-markdown/html-to-markdown.vue
+++ b/src/tools/html-to-markdown/html-to-markdown.vue
@@ -2,14 +2,16 @@
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertHtmlToMarkdown } from './html-to-markdown.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => withDefaultOnError(() => convertHtmlToMarkdown(value), '');
 </script>
 
 <template>
   <format-transformer
-    input-label="Your HTML"
-    input-placeholder="Paste your HTML here..."
-    output-label="Markdown from your HTML"
+    :input-label="t('tools.html-to-markdown.inputLabel')"
+    :input-placeholder="t('tools.html-to-markdown.inputPlaceholder')"
+    :output-label="t('tools.html-to-markdown.outputLabel')"
     output-language="markdown"
     download-file-name="content.md"
     :transformer="transformer"

--- a/src/tools/json-minify/json-minify.vue
+++ b/src/tools/json-minify/json-minify.vue
@@ -4,6 +4,8 @@ import JSON5 from 'json5';
 import { withDefaultOnError } from '@/utils/defaults';
 import { minifyJson } from './json-minify.service';
 
+const { t } = useI18n();
+
 const defaultValue = '{\n\t"hello": [\n\t\t"world"\n\t]\n}';
 const transformer = (value: string) => withDefaultOnError(() => minifyJson(value), '');
 
@@ -17,10 +19,10 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your raw JSON"
+    :input-label="t('tools.json-minify.inputLabel')"
     :input-default="defaultValue"
-    input-placeholder="Paste your raw JSON here..."
-    output-label="Minified version of your JSON"
+    :input-placeholder="t('tools.json-minify.inputPlaceholder')"
+    :output-label="t('tools.json-minify.outputLabel')"
     output-language="json"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/json-sort-keys/json-sort-keys.vue
+++ b/src/tools/json-sort-keys/json-sort-keys.vue
@@ -4,12 +4,14 @@ import { isNotThrowing } from '@/utils/boolean';
 import { withDefaultOnError } from '@/utils/defaults';
 import { sortJsonKeys } from './json-sort-keys.service';
 
+const { t } = useI18n();
+
 const order = ref<'asc' | 'desc'>('asc');
 
-const orderOptions = [
-  { label: 'Ascending (A→Z)', value: 'asc' },
-  { label: 'Descending (Z→A)', value: 'desc' },
-];
+const orderOptions = computed(() => [
+  { label: t('tools.json-sort-keys.ascending'), value: 'asc' },
+  { label: t('tools.json-sort-keys.descending'), value: 'desc' },
+]);
 
 const transformer = computed(() => (value: string) =>
   withDefaultOnError(() => sortJsonKeys(value, { order: order.value }), ''),
@@ -28,16 +30,16 @@ const rules = computed<UseValidationRule<string>[]>(() => [
     <div mb-2 flex justify-end>
       <c-select
         v-model:value="order"
-        label="Key order"
+        :label="t('tools.json-sort-keys.keyOrder')"
         :options="orderOptions"
         w-56
       />
     </div>
 
     <format-transformer
-      input-label="Your JSON"
-      input-placeholder="Paste your JSON here..."
-      output-label="JSON with sorted keys"
+      :input-label="t('tools.json-sort-keys.inputLabel')"
+      :input-placeholder="t('tools.json-sort-keys.inputPlaceholder')"
+      :output-label="t('tools.json-sort-keys.outputLabel')"
       output-language="json"
       download-file-name="sorted.json"
       :input-validation-rules="rules"

--- a/src/tools/json-to-csv/json-to-csv.vue
+++ b/src/tools/json-to-csv/json-to-csv.vue
@@ -4,6 +4,8 @@ import JSON5 from 'json5';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertArrayToCsv } from './json-to-csv.service';
 
+const { t } = useI18n();
+
 function transformer(value: string) {
   return withDefaultOnError(() => {
     if (value === '') {
@@ -23,9 +25,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your raw JSON"
-    input-placeholder="Paste your raw JSON here..."
-    output-label="CSV version of your JSON"
+    :input-label="t('tools.json-to-csv.inputLabel')"
+    :input-placeholder="t('tools.json-to-csv.inputPlaceholder')"
+    :output-label="t('tools.json-to-csv.outputLabel')"
     :input-validation-rules="rules"
     :transformer="transformer"
   />

--- a/src/tools/json-to-toml/json-to-toml.vue
+++ b/src/tools/json-to-toml/json-to-toml.vue
@@ -4,6 +4,8 @@ import JSON5 from 'json5';
 import { withDefaultOnError } from '../../utils/defaults';
 import { convertJsonToToml } from './json-to-toml.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => value.trim() === '' ? '' : withDefaultOnError(() => convertJsonToToml(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -16,9 +18,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your JSON"
-    input-placeholder="Paste your JSON here..."
-    output-label="TOML from your JSON"
+    :input-label="t('tools.json-to-toml.inputLabel')"
+    :input-placeholder="t('tools.json-to-toml.inputPlaceholder')"
+    :output-label="t('tools.json-to-toml.outputLabel')"
     output-language="toml"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/json-to-typescript/json-to-typescript.vue
+++ b/src/tools/json-to-typescript/json-to-typescript.vue
@@ -4,6 +4,8 @@ import { isNotThrowing } from '@/utils/boolean';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertJsonToTypescript } from './json-to-typescript.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => withDefaultOnError(() => convertJsonToTypescript(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -16,9 +18,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your JSON"
-    input-placeholder="Paste your JSON here..."
-    output-label="TypeScript interfaces"
+    :input-label="t('tools.json-to-typescript.inputLabel')"
+    :input-placeholder="t('tools.json-to-typescript.inputPlaceholder')"
+    :output-label="t('tools.json-to-typescript.outputLabel')"
     output-language="typescript"
     download-file-name="types.ts"
     :input-validation-rules="rules"

--- a/src/tools/json-to-xml/json-to-xml.vue
+++ b/src/tools/json-to-xml/json-to-xml.vue
@@ -4,6 +4,8 @@ import JSON5 from 'json5';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertJsonToXml } from './json-to-xml.service';
 
+const { t } = useI18n();
+
 const defaultValue = '{"a":{"_attributes":{"x":"1.234","y":"It\'s"}}}';
 function transformer(value: string) {
   return withDefaultOnError(() => convertJsonToXml(value), '');
@@ -19,10 +21,10 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your JSON content"
+    :input-label="t('tools.json-to-xml.inputLabel')"
     :input-default="defaultValue"
-    input-placeholder="Paste your JSON content here..."
-    output-label="Converted XML"
+    :input-placeholder="t('tools.json-to-xml.inputPlaceholder')"
+    :output-label="t('tools.json-to-xml.outputLabel')"
     output-language="xml"
     :transformer="transformer"
     :input-validation-rules="rules"

--- a/src/tools/json-to-yaml-converter/json-to-yaml.vue
+++ b/src/tools/json-to-yaml-converter/json-to-yaml.vue
@@ -4,6 +4,8 @@ import { isNotThrowing } from '@/utils/boolean';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertJsonToYaml } from './json-to-yaml.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => withDefaultOnError(() => convertJsonToYaml(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -16,9 +18,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your JSON"
-    input-placeholder="Paste your JSON here..."
-    output-label="YAML from your JSON"
+    :input-label="t('tools.json-to-yaml-converter.inputLabel')"
+    :input-placeholder="t('tools.json-to-yaml-converter.inputPlaceholder')"
+    :output-label="t('tools.json-to-yaml-converter.outputLabel')"
     output-language="yaml"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/list-converter/list-converter.vue
+++ b/src/tools/list-converter/list-converter.vue
@@ -3,6 +3,8 @@ import type { ConvertOptions } from './list-converter.types';
 import { useStorage } from '@vueuse/core';
 import { convert } from './list-converter.models';
 
+const { t } = useI18n();
+
 const sortOrderOptions = [
   {
     label: 'Sort ascending',
@@ -115,9 +117,9 @@ function transformer(value: string) {
     </div>
   </div>
   <format-transformer
-    input-label="Your input data"
-    input-placeholder="Paste your input data here..."
-    output-label="Your transformed data"
+    :input-label="t('tools.list-converter.inputLabel')"
+    :input-placeholder="t('tools.list-converter.inputPlaceholder')"
+    :output-label="t('tools.list-converter.outputLabel')"
     :transformer="transformer"
   />
 </template>

--- a/src/tools/toml-to-json/toml-to-json.vue
+++ b/src/tools/toml-to-json/toml-to-json.vue
@@ -3,6 +3,8 @@ import type { UseValidationRule } from '@/composable/validation';
 import { withDefaultOnError } from '../../utils/defaults';
 import { convertTomlToJson, isValidToml } from './toml-to-json.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => value === '' ? '' : withDefaultOnError(() => convertTomlToJson(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -15,9 +17,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your TOML"
-    input-placeholder="Paste your TOML here..."
-    output-label="JSON from your TOML"
+    :input-label="t('tools.toml-to-json.inputLabel')"
+    :input-placeholder="t('tools.toml-to-json.inputPlaceholder')"
+    :output-label="t('tools.toml-to-json.outputLabel')"
     output-language="json"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/toml-to-yaml/toml-to-yaml.vue
+++ b/src/tools/toml-to-yaml/toml-to-yaml.vue
@@ -4,6 +4,8 @@ import { withDefaultOnError } from '../../utils/defaults';
 import { isValidToml } from '../toml-to-json/toml-to-json.service';
 import { convertTomlToYaml } from './toml-to-yaml.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => value.trim() === '' ? '' : withDefaultOnError(() => convertTomlToYaml(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -16,9 +18,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your TOML"
-    input-placeholder="Paste your TOML here..."
-    output-label="YAML from your TOML"
+    :input-label="t('tools.toml-to-yaml.inputLabel')"
+    :input-placeholder="t('tools.toml-to-yaml.inputPlaceholder')"
+    :output-label="t('tools.toml-to-yaml.outputLabel')"
     output-language="yaml"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/xml-formatter/xml-formatter.vue
+++ b/src/tools/xml-formatter/xml-formatter.vue
@@ -2,6 +2,8 @@
 import type { UseValidationRule } from '@/composable/validation';
 import { formatXml, isValidXML } from './xml-formatter.service';
 
+const { t } = useI18n();
+
 const defaultValue = '<hello><world>foo</world><world>bar</world></hello>';
 const indentSize = useStorage('xml-formatter:indent-size', 2);
 const collapseContent = useStorage('xml-formatter:collapse-content', true);
@@ -35,9 +37,9 @@ const rules: UseValidationRule<string>[] = [
   </div>
 
   <format-transformer
-    input-label="Your XML"
-    input-placeholder="Paste your XML here..."
-    output-label="Formatted XML from your XML"
+    :input-label="t('tools.xml-formatter.inputLabel')"
+    :input-placeholder="t('tools.xml-formatter.inputPlaceholder')"
+    :output-label="t('tools.xml-formatter.outputLabel')"
     output-language="xml"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/xml-to-json/xml-to-json.vue
+++ b/src/tools/xml-to-json/xml-to-json.vue
@@ -4,6 +4,8 @@ import { withDefaultOnError } from '@/utils/defaults';
 import { isValidXML } from '../xml-formatter/xml-formatter.service';
 import { convertXmlToJson } from './xml-to-json.service';
 
+const { t } = useI18n();
+
 const defaultValue = '<a x="1.234" y="It\'s"/>';
 function transformer(value: string) {
   return withDefaultOnError(() => convertXmlToJson(value), '');
@@ -19,10 +21,10 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your XML content"
+    :input-label="t('tools.xml-to-json.inputLabel')"
     :input-default="defaultValue"
-    input-placeholder="Paste your XML content here..."
-    output-label="Converted JSON"
+    :input-placeholder="t('tools.xml-to-json.inputPlaceholder')"
+    :output-label="t('tools.xml-to-json.outputLabel')"
     output-language="json"
     :transformer="transformer"
     :input-validation-rules="rules"

--- a/src/tools/yaml-to-json-converter/yaml-to-json.vue
+++ b/src/tools/yaml-to-json-converter/yaml-to-json.vue
@@ -5,6 +5,8 @@ import { isNotThrowing } from '@/utils/boolean';
 import { withDefaultOnError } from '@/utils/defaults';
 import { convertYamlToJson } from './yaml-to-json.service';
 
+const { t } = useI18n();
+
 function transformer(value: string) {
   return withDefaultOnError(() => convertYamlToJson(value), '');
 }
@@ -19,9 +21,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your YAML"
-    input-placeholder="Paste your yaml here..."
-    output-label="JSON from your YAML"
+    :input-label="t('tools.yaml-to-json-converter.inputLabel')"
+    :input-placeholder="t('tools.yaml-to-json-converter.inputPlaceholder')"
+    :output-label="t('tools.yaml-to-json-converter.outputLabel')"
     output-language="json"
     :input-validation-rules="rules"
     :transformer="transformer"

--- a/src/tools/yaml-to-toml/yaml-to-toml.vue
+++ b/src/tools/yaml-to-toml/yaml-to-toml.vue
@@ -4,6 +4,8 @@ import { parse as parseYaml } from 'yaml';
 import { withDefaultOnError } from '../../utils/defaults';
 import { convertYamlToToml } from './yaml-to-toml.service';
 
+const { t } = useI18n();
+
 const transformer = (value: string) => value.trim() === '' ? '' : withDefaultOnError(() => convertYamlToToml(value), '');
 
 const rules: UseValidationRule<string>[] = [
@@ -16,9 +18,9 @@ const rules: UseValidationRule<string>[] = [
 
 <template>
   <format-transformer
-    input-label="Your YAML"
-    input-placeholder="Paste your YAML here..."
-    output-label="TOML from your YAML"
+    :input-label="t('tools.yaml-to-toml.inputLabel')"
+    :input-placeholder="t('tools.yaml-to-toml.inputPlaceholder')"
+    :output-label="t('tools.yaml-to-toml.outputLabel')"
     output-language="toml"
     :input-validation-rules="rules"
     :transformer="transformer"


### PR DESCRIPTION
## Summary

A large in-tool i18n batch: the entire family of converter tools built on the shared `FormatTransformer` component, done in one PR (one CI run) rather than a handful of small PRs.

## Changes (two commits)

1. **`i18n(FormatTransformer)`** — Internationalise the shared component's **"Import file"** and **"Download"** buttons via a new top-level `formatTransformer` section in `locales/en.yml`. Because these buttons are shared, this one change translates them across *every* converter built on the component.

2. **`i18n` the 16 converter tools** — Move the input/output labels and input placeholders into `locales/en.yml` and bind them through `useI18n()` for: **CSV→JSON, HTML→Markdown, JSON minify, JSON sort keys, JSON→CSV/TOML/TypeScript/XML/YAML, list converter, TOML→JSON/YAML, XML formatter, XML→JSON, YAML→JSON/TOML.** Also internationalises the extra controls on **CSV→JSON** (delimiter field, header switch) and **JSON sort keys** (key-order select + its ascending/descending options).

## Testing (thorough — only the GitHub push was batched)

- `pnpm test` — all green (864 tests)
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm build` — succeeds
- i18n coverage test stays at 100%
- Real-browser verification across six converters: **no raw-key leakage**, the Import/Download buttons render translated, and screenshot-confirmed the CSV→JSON (Delimiter / First row is a header) and JSON-sort-keys (Key order / Ascending) controls render correctly

## Notes

- English-only locale entries added; other locales fall back to English per the repo convention. No new dependencies, no service/logic changes (so unit coverage is unchanged).
- This is the first of a few larger batches that will cover the remaining hardcoded-UI tools; grouping many tools per PR to minimise CI/build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_