### PR TITLE
feat(i18n): internationalise the Crypto category tools (9 tools + pdf sub-component)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -77,6 +77,14 @@ tools:
   password-strength-analyser:
     title: Password strength analyser
     description: Discover the strength of your password with this client-side-only password strength analyser and crack time estimation tool.
+    passwordPlaceholder: Enter a password...
+    crackDuration: Duration to crack this password with brute force
+    passwordLength: 'Password length:'
+    entropy: 'Entropy:'
+    charsetSize: 'Character set size:'
+    score: 'Score:'
+    note: 'Note: '
+    noteText: The computed strength is based on the time it would take to crack the password using a brute force approach, it does not take into account the possibility of a dictionary attack.
 
   chronometer:
     title: Chronometer
@@ -130,6 +138,23 @@ tools:
   bcrypt:
     title: Bcrypt
     description: Hash and compare text string using bcrypt. Bcrypt is a password-hashing function based on the Blowfish cipher.
+    hash:
+      title: Hash
+      stringLabel: 'Your string: '
+      stringPlaceholder: Your string to bcrypt...
+      saltCount: 'Salt count: '
+      saltCountPlaceholder: Salt rounds...
+      copyHash: Copy hash
+    copied: Hashed string copied to the clipboard
+    compare:
+      title: Compare string with hash
+      stringLabel: 'Your string: '
+      stringPlaceholder: Your string to compare...
+      hashLabel: 'Your hash: '
+      hashPlaceholder: Your hash to compare...
+      doTheyMatch: 'Do they match ? '
+      matchYes: 'Yes'
+      matchNo: 'No'
 
   crontab-generator:
     title: Crontab generator
@@ -166,6 +191,20 @@ tools:
   encryption:
     title: Encrypt / decrypt text
     description: Encrypt clear text and decrypt ciphertext using crypto algorithms like AES, TripleDES, Rabbit or RC4.
+    secretKey: 'Your secret key:'
+    algorithm: 'Encryption algorithm:'
+    outputPlaceholder: Your string hash
+    encrypt:
+      title: Encrypt
+      textLabel: 'Your text:'
+      textPlaceholder: The string to cypher
+      outputLabel: 'Your text encrypted:'
+    decrypt:
+      title: Decrypt
+      textLabel: 'Your encrypted text:'
+      outputLabel: 'Your decrypted text:'
+      errorTitle: Error while decrypting
+    unableToDecrypt: Unable to decrypt your text
 
   random-port-generator:
     title: Random port generator
@@ -189,10 +228,36 @@ tools:
   hmac-generator:
     title: Hmac generator
     description: Computes a hash-based message authentication code (HMAC) using a secret key and your favorite hashing function.
+    plainTextLabel: Plain text to compute the hash
+    plainTextPlaceholder: Plain text to compute the hash...
+    secretLabel: Secret key
+    secretPlaceholder: Enter the secret key...
+    hashingFunction: Hashing function
+    hashingFunctionPlaceholder: Select an hashing function...
+    outputEncoding: Output encoding
+    outputEncodingPlaceholder: Select the result encoding...
+    encoding:
+      binary: Binary (base 2)
+      hexadecimal: Hexadecimal (base 16)
+      base64: Base64 (base 64)
+      base64url: Base64-url (base 64 with url safe chars)
+    hmacLabel: HMAC of your text
+    hmacPlaceholder: The result of the HMAC...
+    copyHmac: Copy HMAC
 
   bip39-generator:
     title: BIP39 passphrase generator
     description: Generate a BIP39 passphrase from an existing or random mnemonic, or get the mnemonic from the passphrase.
+    language: 'Language:'
+    entropy: 'Entropy (seed):'
+    entropyPlaceholder: Your string...
+    passphrase: 'Passphrase (mnemonic):'
+    passphrasePlaceholder: Your mnemonic...
+    entropyLengthError: Entropy length should be >= 16, <= 32 and be a multiple of 4
+    entropyHexError: Entropy should be an hexadecimal string
+    invalidMnemonic: Invalid mnemonic
+    entropyCopied: Entropy copied to the clipboard
+    passphraseCopied: Passphrase copied to the clipboard
 
   base64-file-converter:
     title: Base64 file converter
@@ -327,6 +392,11 @@ tools:
   rsa-key-pair-generator:
     title: RSA key pair generator
     description: Generate a new random RSA private and public pem certificate key pair.
+    bits: 'Bits :'
+    bitsError: Bits should be 256 <= bits <= 16384 and be a multiple of 8
+    refresh: Refresh key-pair
+    publicKey: Public key
+    privateKey: Private key
 
   html-wysiwyg-editor:
     title: HTML WYSIWYG editor
@@ -385,6 +455,14 @@ tools:
   hash-text:
     title: Hash text
     description: 'Hash a text string using the function you need : MD5, SHA1, SHA256, SHA224, SHA512, SHA384, SHA3 or RIPEMD160'
+    textLabel: 'Your text to hash:'
+    textPlaceholder: Your string to hash...
+    digestEncoding: Digest encoding
+    encoding:
+      binary: Binary (base 2)
+      hexadecimal: Hexadecimal (base 16)
+      base64: Base64 (base 64)
+      base64url: Base64url (base 64 with url safe chars)
 
   json-to-toml:
     title: JSON to TOML
@@ -400,6 +478,24 @@ tools:
   pdf-signature-checker:
     title: PDF signature checker
     description: Verify the signatures of a PDF file. A signed PDF file contains one or more signatures that may be used to determine whether the contents of the file have been altered since the file was signed.
+    dragDrop: Drag and drop a PDF file here, or click to select a file
+    noSignatures: No signatures found in the provided file.
+    signatureCertificates: 'Signature {number} certificates :'
+    details:
+      validityPeriod: Validity period
+      issuedBy: Issued by
+      issuedTo: Issued to
+      pemCertificate: PEM certificate
+      certificateName: Certificate {number}
+      notBefore: Not before
+      notAfter: Not after
+      commonName: Common name
+      organizationName: Organization name
+      countryName: Country name
+      localityName: Locality name
+      organizationalUnitName: Organizational unit name
+      stateOrProvinceName: State or province name
+      viewPemCert: View PEM cert
 
   json-minify:
     title: JSON minify
@@ -411,6 +507,14 @@ tools:
   ulid-generator:
     title: ULID generator
     description: Generate random Universally Unique Lexicographically Sortable Identifier (ULID).
+    quantity: 'Quantity:'
+    format: 'Format: '
+    formats:
+      raw: Raw
+      json: JSON
+    refresh: Refresh
+    copy: Copy
+    copied: ULIDs copied to the clipboard
 
   string-obfuscator:
     title: String obfuscator

--- a/src/tools/bcrypt/bcrypt.vue
+++ b/src/tools/bcrypt/bcrypt.vue
@@ -3,12 +3,14 @@ import { useThemeVars } from 'naive-ui';
 import { useCopy } from '@/composable/copy';
 import { compareStringWithHash, hashString } from './bcrypt.service';
 
+const { t } = useI18n();
+
 const themeVars = useThemeVars();
 
 const input = ref('');
 const saltCount = ref(10);
 const hashed = computed(() => hashString({ string: input.value, saltCount: saltCount.value }));
-const { copy } = useCopy({ source: hashed, text: 'Hashed string copied to the clipboard' });
+const { copy } = useCopy({ source: hashed, text: t('tools.bcrypt.copied') });
 
 const compareString = ref('');
 const compareHash = ref('');
@@ -16,41 +18,41 @@ const compareMatch = computed(() => compareStringWithHash({ string: compareStrin
 </script>
 
 <template>
-  <c-card title="Hash">
+  <c-card :title="t('tools.bcrypt.hash.title')">
     <c-input-text
       v-model:value="input"
-      placeholder="Your string to bcrypt..."
+      :placeholder="t('tools.bcrypt.hash.stringPlaceholder')"
       raw-text
-      label="Your string: "
+      :label="t('tools.bcrypt.hash.stringLabel')"
       label-position="left"
       label-align="right"
       label-width="120px"
       mb-2
     />
-    <n-form-item label="Salt count: " label-placement="left" label-width="120">
-      <n-input-number v-model:value="saltCount" placeholder="Salt rounds..." :max="100" :min="0" w-full />
+    <n-form-item :label="t('tools.bcrypt.hash.saltCount')" label-placement="left" label-width="120">
+      <n-input-number v-model:value="saltCount" :placeholder="t('tools.bcrypt.hash.saltCountPlaceholder')" :max="100" :min="0" w-full />
     </n-form-item>
 
     <c-input-text :value="hashed" readonly text-center />
 
     <div mt-5 flex justify-center>
       <c-button @click="copy()">
-        Copy hash
+        {{ t('tools.bcrypt.hash.copyHash') }}
       </c-button>
     </div>
   </c-card>
 
-  <c-card title="Compare string with hash">
+  <c-card :title="t('tools.bcrypt.compare.title')">
     <n-form label-width="120">
-      <n-form-item label="Your string: " label-placement="left">
-        <c-input-text v-model:value="compareString" placeholder="Your string to compare..." raw-text />
+      <n-form-item :label="t('tools.bcrypt.compare.stringLabel')" label-placement="left">
+        <c-input-text v-model:value="compareString" :placeholder="t('tools.bcrypt.compare.stringPlaceholder')" raw-text />
       </n-form-item>
-      <n-form-item label="Your hash: " label-placement="left">
-        <c-input-text v-model:value="compareHash" placeholder="Your hash to compare..." raw-text />
+      <n-form-item :label="t('tools.bcrypt.compare.hashLabel')" label-placement="left">
+        <c-input-text v-model:value="compareHash" :placeholder="t('tools.bcrypt.compare.hashPlaceholder')" raw-text />
       </n-form-item>
-      <n-form-item label="Do they match ? " label-placement="left" :show-feedback="false">
+      <n-form-item :label="t('tools.bcrypt.compare.doTheyMatch')" label-placement="left" :show-feedback="false">
         <div class="compare-result" :class="{ positive: compareMatch }">
-          {{ compareMatch ? 'Yes' : 'No' }}
+          {{ compareMatch ? t('tools.bcrypt.compare.matchYes') : t('tools.bcrypt.compare.matchNo') }}
         </div>
       </n-form-item>
     </n-form>

--- a/src/tools/bip39-generator/bip39-generator.vue
+++ b/src/tools/bip39-generator/bip39-generator.vue
@@ -14,6 +14,8 @@ import {
   languages,
 } from './bip39-generator.service';
 
+const { t } = useI18n();
+
 const entropy = ref(generateRandomEntropy());
 const passphraseInput = ref('');
 
@@ -36,11 +38,11 @@ const entropyValidation = useValidation({
   rules: [
     {
       validator: (value: string) => isEntropyLengthValid(value),
-      message: 'Entropy length should be >= 16, <= 32 and be a multiple of 4',
+      message: t('tools.bip39-generator.entropyLengthError'),
     },
     {
       validator: (value: string) => isEntropyHexadecimal(value),
-      message: 'Entropy should be an hexadecimal string',
+      message: t('tools.bip39-generator.entropyHexError'),
     },
   ],
 });
@@ -51,7 +53,7 @@ const mnemonicValidation = useValidation({
     {
       validator: (value: string) =>
         isNotThrowing(() => convertMnemonicToEntropy({ mnemonic: value, language: language.value })),
-      message: 'Invalid mnemonic',
+      message: t('tools.bip39-generator.invalidMnemonic'),
     },
   ],
 });
@@ -60,8 +62,8 @@ function refreshEntropy() {
   entropy.value = generateRandomEntropy();
 }
 
-const { copy: copyEntropy } = useCopy({ source: entropy, text: 'Entropy copied to the clipboard' });
-const { copy: copyPassphrase } = useCopy({ source: passphrase, text: 'Passphrase copied to the clipboard' });
+const { copy: copyEntropy } = useCopy({ source: entropy, text: t('tools.bip39-generator.entropyCopied') });
+const { copy: copyPassphrase } = useCopy({ source: passphrase, text: t('tools.bip39-generator.passphraseCopied') });
 </script>
 
 <template>
@@ -71,18 +73,18 @@ const { copy: copyPassphrase } = useCopy({ source: passphrase, text: 'Passphrase
         <c-select
           v-model:value="language"
           searchable
-          label="Language:"
+          :label="t('tools.bip39-generator.language')"
           :options="Object.keys(languages)"
         />
       </n-gi>
       <n-gi span="2">
         <n-form-item
-          label="Entropy (seed):"
+          :label="t('tools.bip39-generator.entropy')"
           :feedback="entropyValidation.message"
           :validation-status="entropyValidation.status"
         >
           <n-input-group>
-            <c-input-text v-model:value="entropy" placeholder="Your string..." />
+            <c-input-text v-model:value="entropy" :placeholder="t('tools.bip39-generator.entropyPlaceholder')" />
 
             <c-button @click="refreshEntropy()">
               <n-icon size="22">
@@ -99,12 +101,12 @@ const { copy: copyPassphrase } = useCopy({ source: passphrase, text: 'Passphrase
       </n-gi>
     </n-grid>
     <n-form-item
-      label="Passphrase (mnemonic):"
+      :label="t('tools.bip39-generator.passphrase')"
       :feedback="mnemonicValidation.message"
       :validation-status="mnemonicValidation.status"
     >
       <n-input-group>
-        <c-input-text v-model:value="passphrase" placeholder="Your mnemonic..." raw-text />
+        <c-input-text v-model:value="passphrase" :placeholder="t('tools.bip39-generator.passphrasePlaceholder')" raw-text />
 
         <c-button @click="copyPassphrase()">
           <n-icon size="22" :component="Copy" />

--- a/src/tools/encryption/encryption.vue
+++ b/src/tools/encryption/encryption.vue
@@ -2,6 +2,8 @@
 import { computedCatch } from '@/composable/computed/catchedComputed';
 import { algos, decryptText, encryptText } from './encryption.service';
 
+const { t } = useI18n();
+
 const cypherInput = ref('Lorem ipsum dolor sit amet');
 const cypherAlgo = ref<keyof typeof algos>('AES');
 const cypherSecret = ref('my secret key');
@@ -14,65 +16,65 @@ const decryptAlgo = ref<keyof typeof algos>('AES');
 const decryptSecret = ref('my secret key');
 const [decryptOutput, decryptError] = computedCatch(() => decryptText({ text: decryptInput.value, secret: decryptSecret.value, algo: decryptAlgo.value }), {
   defaultValue: '',
-  defaultErrorMessage: 'Unable to decrypt your text',
+  defaultErrorMessage: t('tools.encryption.unableToDecrypt'),
 });
 </script>
 
 <template>
-  <c-card title="Encrypt">
+  <c-card :title="t('tools.encryption.encrypt.title')">
     <div flex gap-3>
       <c-input-text
         v-model:value="cypherInput"
-        label="Your text:"
-        placeholder="The string to cypher"
+        :label="t('tools.encryption.encrypt.textLabel')"
+        :placeholder="t('tools.encryption.encrypt.textPlaceholder')"
         rows="4"
         multiline raw-text monospace autosize flex-1
       />
       <div flex flex-1 flex-col gap-2>
-        <c-input-text v-model:value="cypherSecret" label="Your secret key:" clearable raw-text />
+        <c-input-text v-model:value="cypherSecret" :label="t('tools.encryption.secretKey')" clearable raw-text />
 
         <c-select
           v-model:value="cypherAlgo"
-          label="Encryption algorithm:"
+          :label="t('tools.encryption.algorithm')"
           :options="Object.keys(algos).map((label) => ({ label, value: label }))"
         />
       </div>
     </div>
     <c-input-text
-      label="Your text encrypted:"
+      :label="t('tools.encryption.encrypt.outputLabel')"
       :value="cypherOutput"
       rows="3"
-      placeholder="Your string hash"
+      :placeholder="t('tools.encryption.outputPlaceholder')"
       multiline monospace readonly autosize mt-5
     />
   </c-card>
-  <c-card title="Decrypt">
+  <c-card :title="t('tools.encryption.decrypt.title')">
     <div flex gap-3>
       <c-input-text
         v-model:value="decryptInput"
-        label="Your encrypted text:"
-        placeholder="The string to cypher"
+        :label="t('tools.encryption.decrypt.textLabel')"
+        :placeholder="t('tools.encryption.encrypt.textPlaceholder')"
         rows="4"
         multiline raw-text monospace autosize flex-1
       />
       <div flex flex-1 flex-col gap-2>
-        <c-input-text v-model:value="decryptSecret" label="Your secret key:" clearable raw-text />
+        <c-input-text v-model:value="decryptSecret" :label="t('tools.encryption.secretKey')" clearable raw-text />
 
         <c-select
           v-model:value="decryptAlgo"
-          label="Encryption algorithm:"
+          :label="t('tools.encryption.algorithm')"
           :options="Object.keys(algos).map((label) => ({ label, value: label }))"
         />
       </div>
     </div>
-    <c-alert v-if="decryptError" type="warning" mt-12 title="Error while decrypting">
+    <c-alert v-if="decryptError" type="warning" mt-12 :title="t('tools.encryption.decrypt.errorTitle')">
       {{ decryptError }}
     </c-alert>
     <c-input-text
       v-else
-      label="Your decrypted text:"
+      :label="t('tools.encryption.decrypt.outputLabel')"
       :value="decryptOutput"
-      placeholder="Your string hash"
+      :placeholder="t('tools.encryption.outputPlaceholder')"
       rows="3"
       multiline monospace readonly autosize mt-5
     />

--- a/src/tools/hash-text/hash-text.vue
+++ b/src/tools/hash-text/hash-text.vue
@@ -6,6 +6,8 @@ import { useQueryParam } from '@/composable/queryParams';
 import InputCopyable from '../../components/InputCopyable.vue';
 import { convertHexToBin } from './hash-text.service';
 
+const { t } = useI18n();
+
 const algos = {
   MD5,
   SHA1,
@@ -37,29 +39,29 @@ const hashText = (algo: AlgoNames, value: string) => formatWithEncoding(algos[al
 <template>
   <div>
     <c-card>
-      <c-input-text v-model:value="clearText" multiline raw-text placeholder="Your string to hash..." rows="3" autosize autofocus label="Your text to hash:" />
+      <c-input-text v-model:value="clearText" multiline raw-text :placeholder="t('tools.hash-text.textPlaceholder')" rows="3" autosize autofocus :label="t('tools.hash-text.textLabel')" />
 
       <n-divider />
 
       <c-select
         v-model:value="encoding"
         mb-4
-        label="Digest encoding"
+        :label="t('tools.hash-text.digestEncoding')"
         :options="[
           {
-            label: 'Binary (base 2)',
+            label: t('tools.hash-text.encoding.binary'),
             value: 'Bin',
           },
           {
-            label: 'Hexadecimal (base 16)',
+            label: t('tools.hash-text.encoding.hexadecimal'),
             value: 'Hex',
           },
           {
-            label: 'Base64 (base 64)',
+            label: t('tools.hash-text.encoding.base64'),
             value: 'Base64',
           },
           {
-            label: 'Base64url (base 64 with url safe chars)',
+            label: t('tools.hash-text.encoding.base64url'),
             value: 'Base64url',
           },
         ]"

--- a/src/tools/hmac-generator/hmac-generator.vue
+++ b/src/tools/hmac-generator/hmac-generator.vue
@@ -3,6 +3,8 @@ import type { Encoding } from './hmac-generator.service';
 import { useCopy } from '@/composable/copy';
 import { algos, computeHmac } from './hmac-generator.service';
 
+const { t } = useI18n();
+
 const plainText = ref('');
 const secret = ref('');
 const hashFunction = ref<keyof typeof algos>('SHA256');
@@ -20,44 +22,44 @@ const { copy } = useCopy({ source: hmac });
 
 <template>
   <div flex flex-col gap-4>
-    <c-input-text v-model:value="plainText" multiline raw-text placeholder="Plain text to compute the hash..." rows="3" autosize autofocus label="Plain text to compute the hash" />
-    <c-input-text v-model:value="secret" raw-text placeholder="Enter the secret key..." label="Secret key" clearable />
+    <c-input-text v-model:value="plainText" multiline raw-text :placeholder="t('tools.hmac-generator.plainTextPlaceholder')" rows="3" autosize autofocus :label="t('tools.hmac-generator.plainTextLabel')" />
+    <c-input-text v-model:value="secret" raw-text :placeholder="t('tools.hmac-generator.secretPlaceholder')" :label="t('tools.hmac-generator.secretLabel')" clearable />
 
     <div flex gap-2>
       <c-select
-        v-model:value="hashFunction" label="Hashing function"
+        v-model:value="hashFunction" :label="t('tools.hmac-generator.hashingFunction')"
         flex-1
-        placeholder="Select an hashing function..."
+        :placeholder="t('tools.hmac-generator.hashingFunctionPlaceholder')"
         :options="Object.keys(algos).map((label) => ({ label, value: label }))"
       />
       <c-select
-        v-model:value="encoding" label="Output encoding"
+        v-model:value="encoding" :label="t('tools.hmac-generator.outputEncoding')"
         flex-1
-        placeholder="Select the result encoding..."
+        :placeholder="t('tools.hmac-generator.outputEncodingPlaceholder')"
         :options="[
           {
-            label: 'Binary (base 2)',
+            label: t('tools.hmac-generator.encoding.binary'),
             value: 'Bin',
           },
           {
-            label: 'Hexadecimal (base 16)',
+            label: t('tools.hmac-generator.encoding.hexadecimal'),
             value: 'Hex',
           },
           {
-            label: 'Base64 (base 64)',
+            label: t('tools.hmac-generator.encoding.base64'),
             value: 'Base64',
           },
           {
-            label: 'Base64-url (base 64 with url safe chars)',
+            label: t('tools.hmac-generator.encoding.base64url'),
             value: 'Base64url',
           },
         ]"
       />
     </div>
-    <input-copyable v-model:value="hmac" type="textarea" placeholder="The result of the HMAC..." label="HMAC of your text" />
+    <input-copyable v-model:value="hmac" type="textarea" :placeholder="t('tools.hmac-generator.hmacPlaceholder')" :label="t('tools.hmac-generator.hmacLabel')" />
     <div flex justify-center>
       <c-button @click="copy()">
-        Copy HMAC
+        {{ t('tools.hmac-generator.copyHmac') }}
       </c-button>
     </div>
   </div>

--- a/src/tools/password-strength-analyser/password-strength-analyser.vue
+++ b/src/tools/password-strength-analyser/password-strength-analyser.vue
@@ -1,24 +1,26 @@
 <script setup lang="ts">
 import { getPasswordCrackTimeEstimation } from './password-strength-analyser.service';
 
+const { t } = useI18n();
+
 const password = ref('');
 const crackTimeEstimation = computed(() => getPasswordCrackTimeEstimation({ password: password.value }));
 
 const details = computed(() => [
   {
-    label: 'Password length:',
+    label: t('tools.password-strength-analyser.passwordLength'),
     value: crackTimeEstimation.value.passwordLength,
   },
   {
-    label: 'Entropy:',
+    label: t('tools.password-strength-analyser.entropy'),
     value: Math.round(crackTimeEstimation.value.entropy * 100) / 100,
   },
   {
-    label: 'Character set size:',
+    label: t('tools.password-strength-analyser.charsetSize'),
     value: crackTimeEstimation.value.charsetLength,
   },
   {
-    label: 'Score:',
+    label: t('tools.password-strength-analyser.score'),
     value: `${Math.round(crackTimeEstimation.value.score * 100)} / 100`,
   },
 ]);
@@ -29,7 +31,7 @@ const details = computed(() => [
     <c-input-text
       v-model:value="password"
       type="password"
-      placeholder="Enter a password..."
+      :placeholder="t('tools.password-strength-analyser.passwordPlaceholder')"
       clearable
       autofocus
       raw-text
@@ -38,7 +40,7 @@ const details = computed(() => [
 
     <c-card text-center>
       <div op-60>
-        Duration to crack this password with brute force
+        {{ t('tools.password-strength-analyser.crackDuration') }}
       </div>
       <div text-2xl data-test-id="crack-duration">
         {{ crackTimeEstimation.crackDurationFormatted }}
@@ -55,8 +57,8 @@ const details = computed(() => [
       </div>
     </c-card>
     <div op-70>
-      <span font-bold>Note: </span>
-      The computed strength is based on the time it would take to crack the password using a brute force approach, it does not take into account the possibility of a dictionary attack.
+      <span font-bold>{{ t('tools.password-strength-analyser.note') }}</span>
+      {{ t('tools.password-strength-analyser.noteText') }}
     </div>
   </div>
 </template>

--- a/src/tools/pdf-signature-checker/components/pdf-signature-details.vue
+++ b/src/tools/pdf-signature-checker/components/pdf-signature-details.vue
@@ -5,12 +5,14 @@ import type { SignatureInfo } from '../pdf-signature-checker.types';
 const props = defineProps<{ signature: SignatureInfo }>();
 const { signature } = toRefs(props);
 
-const tableHeaders = {
-  validityPeriod: 'Validity period',
-  issuedBy: 'Issued by',
-  issuedTo: 'Issued to',
-  pemCertificate: 'PEM certificate',
-};
+const { t } = useI18n();
+
+const tableHeaders = computed(() => ({
+  validityPeriod: t('tools.pdf-signature-checker.details.validityPeriod'),
+  issuedBy: t('tools.pdf-signature-checker.details.issuedBy'),
+  issuedTo: t('tools.pdf-signature-checker.details.issuedTo'),
+  pemCertificate: t('tools.pdf-signature-checker.details.pemCertificate'),
+}));
 
 const certs = computed(() => signature.value.meta.certs.map((certificate, index) => ({
   ...certificate,
@@ -18,7 +20,7 @@ const certs = computed(() => signature.value.meta.certs.map((certificate, index)
     notBefore: new Date(certificate.validityPeriod.notBefore).toLocaleString(),
     notAfter: new Date(certificate.validityPeriod.notAfter).toLocaleString(),
   },
-  certificateName: `Certificate ${index + 1}`,
+  certificateName: t('tools.pdf-signature-checker.details.certificateName', { number: index + 1 }),
 })),
 );
 </script>
@@ -29,10 +31,10 @@ const certs = computed(() => signature.value.meta.certs.map((certificate, index)
       <template #validityPeriod="{ value }">
         <c-key-value-list
           :items="[{
-            label: 'Not before',
+            label: t('tools.pdf-signature-checker.details.notBefore'),
             value: value.notBefore,
           }, {
-            label: 'Not after',
+            label: t('tools.pdf-signature-checker.details.notAfter'),
             value: value.notAfter,
           }]"
         />
@@ -41,22 +43,22 @@ const certs = computed(() => signature.value.meta.certs.map((certificate, index)
       <template #issuedBy="{ value }">
         <c-key-value-list
           :items="[{
-            label: 'Common name',
+            label: t('tools.pdf-signature-checker.details.commonName'),
             value: value.commonName,
           }, {
-            label: 'Organization name',
+            label: t('tools.pdf-signature-checker.details.organizationName'),
             value: value.organizationName,
           }, {
-            label: 'Country name',
+            label: t('tools.pdf-signature-checker.details.countryName'),
             value: value.countryName,
           }, {
-            label: 'Locality name',
+            label: t('tools.pdf-signature-checker.details.localityName'),
             value: value.localityName,
           }, {
-            label: 'Organizational unit name',
+            label: t('tools.pdf-signature-checker.details.organizationalUnitName'),
             value: value.organizationalUnitName,
           }, {
-            label: 'State or province name',
+            label: t('tools.pdf-signature-checker.details.stateOrProvinceName'),
             value: value.stateOrProvinceName,
           }]"
         />
@@ -65,29 +67,29 @@ const certs = computed(() => signature.value.meta.certs.map((certificate, index)
       <template #issuedTo="{ value }">
         <c-key-value-list
           :items="[{
-            label: 'Common name',
+            label: t('tools.pdf-signature-checker.details.commonName'),
             value: value.commonName,
           }, {
-            label: 'Organization name',
+            label: t('tools.pdf-signature-checker.details.organizationName'),
             value: value.organizationName,
           }, {
-            label: 'Country name',
+            label: t('tools.pdf-signature-checker.details.countryName'),
             value: value.countryName,
           }, {
-            label: 'Locality name',
+            label: t('tools.pdf-signature-checker.details.localityName'),
             value: value.localityName,
           }, {
-            label: 'Organizational unit name',
+            label: t('tools.pdf-signature-checker.details.organizationalUnitName'),
             value: value.organizationalUnitName,
           }, {
-            label: 'State or province name',
+            label: t('tools.pdf-signature-checker.details.stateOrProvinceName'),
             value: value.stateOrProvinceName,
           }]"
         />
       </template>
 
       <template #pemCertificate="{ value }">
-        <c-modal-value :value="value" label="View PEM cert">
+        <c-modal-value :value="value" :label="t('tools.pdf-signature-checker.details.viewPemCert')">
           <template #value>
             <div break-all text-xs>
               {{ value }}

--- a/src/tools/pdf-signature-checker/pdf-signature-checker.vue
+++ b/src/tools/pdf-signature-checker/pdf-signature-checker.vue
@@ -4,6 +4,8 @@ import verifyPDF from 'pdf-signature-reader';
 import { formatBytes } from '@/utils/convert';
 import PdfSignatureDetails from './components/pdf-signature-details.vue';
 
+const { t } = useI18n();
+
 const signatures = ref<SignatureInfo[]>([]);
 const status = ref<'idle' | 'parsed' | 'error' | 'loading'>('idle');
 const file = ref<File | null>(null);
@@ -28,7 +30,7 @@ async function onVerifyClicked(uploadedFile: File) {
 <template>
   <div style="flex: 0 0 100%">
     <div mx-auto max-w-600px>
-      <c-file-upload title="Drag and drop a PDF file here, or click to select a file" accept=".pdf" @file-upload="onVerifyClicked" />
+      <c-file-upload :title="t('tools.pdf-signature-checker.dragDrop')" accept=".pdf" @file-upload="onVerifyClicked" />
 
       <c-card v-if="file" mt-4 flex gap-2>
         <div font-bold>
@@ -42,7 +44,7 @@ async function onVerifyClicked(uploadedFile: File) {
 
       <div v-if="status === 'error'">
         <c-alert mt-4>
-          No signatures found in the provided file.
+          {{ t('tools.pdf-signature-checker.noSignatures') }}
         </c-alert>
       </div>
     </div>
@@ -51,7 +53,7 @@ async function onVerifyClicked(uploadedFile: File) {
   <div v-if="status === 'parsed' && signatures.length" style="flex: 0 0 100%" mt-5 flex flex-col gap-4>
     <div v-for="(signature, index) of signatures" :key="index">
       <div mb-2 font-bold>
-        Signature {{ index + 1 }} certificates :
+        {{ t('tools.pdf-signature-checker.signatureCertificates', { number: index + 1 }) }}
       </div>
 
       <PdfSignatureDetails :signature="signature" />

--- a/src/tools/rsa-key-pair-generator/rsa-key-pair-generator.vue
+++ b/src/tools/rsa-key-pair-generator/rsa-key-pair-generator.vue
@@ -5,6 +5,8 @@ import { useValidation } from '@/composable/validation';
 import { withDefaultOnErrorAsync } from '@/utils/defaults';
 import { generateKeyPair } from './rsa-key-pair-generator.service';
 
+const { t } = useI18n();
+
 const bits = ref(2048);
 const emptyCerts = { publicKeyPem: '', privateKeyPem: '' };
 
@@ -12,7 +14,7 @@ const { attrs: bitsValidationAttrs } = useValidation({
   source: bits,
   rules: [
     {
-      message: 'Bits should be 256 <= bits <= 16384 and be a multiple of 8',
+      message: t('tools.rsa-key-pair-generator.bitsError'),
       validator: (value: number) => value >= 256 && value <= 16384 && value % 8 === 0,
     },
   ],
@@ -27,23 +29,23 @@ const [certs, refreshCerts] = computedRefreshableAsync(
 <template>
   <div style="flex: 0 0 100%">
     <div item-style="flex: 1 1 0" style="max-width: 600px" mx-auto flex gap-3>
-      <n-form-item label="Bits :" v-bind="bitsValidationAttrs as any" label-placement="left" label-width="100">
+      <n-form-item :label="t('tools.rsa-key-pair-generator.bits')" v-bind="bitsValidationAttrs as any" label-placement="left" label-width="100">
         <n-input-number v-model:value="bits" min="256" max="16384" step="8" />
       </n-form-item>
 
       <c-button @click="refreshCerts">
-        Refresh key-pair
+        {{ t('tools.rsa-key-pair-generator.refresh') }}
       </c-button>
     </div>
   </div>
 
   <div>
-    <h3>Public key</h3>
+    <h3>{{ t('tools.rsa-key-pair-generator.publicKey') }}</h3>
     <TextareaCopyable :value="certs?.publicKeyPem ?? ''" />
   </div>
 
   <div>
-    <h3>Private key</h3>
+    <h3>{{ t('tools.rsa-key-pair-generator.privateKey') }}</h3>
     <TextareaCopyable :value="certs?.privateKeyPem ?? ''" />
   </div>
 </template>

--- a/src/tools/ulid-generator/ulid-generator.vue
+++ b/src/tools/ulid-generator/ulid-generator.vue
@@ -3,23 +3,28 @@ import { computedRefreshable } from '@/composable/computedRefreshable';
 import { useCopy } from '@/composable/copy';
 import { generateUlids } from './ulid-generator.service';
 
+const { t } = useI18n();
+
 const amount = useStorage('ulid-generator-amount', 1);
-const formats = [{ label: 'Raw', value: 'raw' as const }, { label: 'JSON', value: 'json' as const }];
-const format = useStorage<typeof formats[number]['value']>('ulid-generator-format', formats[0]?.value ?? 'raw');
+const formats = computed(() => [
+  { label: t('tools.ulid-generator.formats.raw'), value: 'raw' as const },
+  { label: t('tools.ulid-generator.formats.json'), value: 'json' as const },
+]);
+const format = useStorage<'raw' | 'json'>('ulid-generator-format', 'raw');
 
 const [ulids, refreshUlids] = computedRefreshable(() => generateUlids({ amount: amount.value, format: format.value }));
 
-const { copy } = useCopy({ source: ulids, text: 'ULIDs copied to the clipboard' });
+const { copy } = useCopy({ source: ulids, text: t('tools.ulid-generator.copied') });
 </script>
 
 <template>
   <div flex flex-col justify-center gap-2>
     <div flex items-center>
-      <label w-75px> Quantity:</label>
+      <label w-75px> {{ t('tools.ulid-generator.quantity') }}</label>
       <n-input-number v-model:value="amount" min="1" max="100" flex-1 />
     </div>
 
-    <c-buttons-select v-model:value="format" :options="formats" label="Format: " label-width="75px" />
+    <c-buttons-select v-model:value="format" :options="formats" :label="t('tools.ulid-generator.format')" label-width="75px" />
 
     <c-card mt-5 flex data-test-id="ulids">
       <pre m-0 m-x-auto>{{ ulids }}</pre>
@@ -27,10 +32,10 @@ const { copy } = useCopy({ source: ulids, text: 'ULIDs copied to the clipboard' 
 
     <div flex justify-center gap-2>
       <c-button data-test-id="refresh" @click="refreshUlids()">
-        Refresh
+        {{ t('tools.ulid-generator.refresh') }}
       </c-button>
       <c-button @click="copy()">
-        Copy
+        {{ t('tools.ulid-generator.copy') }}
       </c-button>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Continues the in-tool i18n sweep, this time covering the entire **Crypto** category. All nine remaining Crypto tools that still had hardcoded English UI now pull their strings from `locales/en.yml` via `useI18n()`, done in one PR (one CI run) rather than nine small ones.

## Changes

Moved the hardcoded labels, placeholders, buttons and validation/clipboard messages into `locales/en.yml` and bound them through `t()` for:

- **hash-text** — text label/placeholder, digest-encoding select + its four encoding options
- **bcrypt** — hash + compare card titles, all form labels/placeholders, copy button, match yes/no, clipboard message
- **ulid-generator** — quantity/format labels, raw/JSON format options, refresh/copy buttons, clipboard message
- **encryption** — encrypt/decrypt card titles, all text/secret/algorithm labels + placeholders, decrypt error title + message
- **bip39-generator** — language/entropy/passphrase labels + placeholders, three validation messages, two clipboard messages
- **hmac-generator** — plain-text/secret/function labels + placeholders, output-encoding select + its four options, HMAC label/placeholder, copy button
- **rsa-key-pair-generator** — bits label + validation message, refresh button, public/private key headings
- **password-strength-analyser** — password placeholder, crack-duration text, four detail row labels, the note
- **pdf-signature-checker** — drag-and-drop title, no-signatures alert, `Signature {n} certificates` heading, plus the certificate-table sub-component (`pdf-signature-details`): headers, key/value labels, `Certificate {n}`, "View PEM cert"

## Testing (thorough — only the GitHub push was batched)

- `pnpm test` — all green (864 tests), i18n coverage stays at 100%
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm build` — succeeds
- Real-browser sweep across all nine tools on the production build: **no raw i18n key leakage** anywhere; the eight tools that render show translated labels correctly.

## Notes

- English-only locale entries added; other locales fall back to English per the repo convention. No new dependencies, no service/logic changes (unit coverage unchanged).
- YAML gotcha avoided: bcrypt's yes/no match labels use `matchYes`/`matchNo` keys rather than `yes`/`no`, which YAML 1.1 would parse as booleans.
- **Pre-existing bug spotted (out of scope here):** in the production/preview build the **bcrypt** tool crashes at load with `ReferenceError: global is not defined` (then `process is not defined`) from `crypto-browserify` — `global`/`process` are only aliased for dev-time dep optimisation, not the production build. This predates this PR (bcrypt's translated labels are correct and will show once it's fixed). I'll address it in a dedicated follow-up PR that properly polyfills `global`+`process` for the production build and verifies bcrypt end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_