### PR TITLE
fix(bcrypt): polyfill node global/process so the tool works in the production build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,21 @@
 import { createHead } from '@vueuse/head';
 import { createPinia } from 'pinia';
 import { registerSW } from 'virtual:pwa-register';
-
 import { createApp } from 'vue';
+
 import shadow from 'vue-shadow-dom';
 import App from './App.vue';
-
 import { i18nPlugin } from './plugins/i18n.plugin';
 
 import { naive } from './plugins/naive.plugin';
 
 import router from './router';
+
+// Installs `global`/`process` shims that browserified deps (e.g.
+// crypto-browserify via bcryptjs) reference at chunk-eval time. This runs
+// during main.ts evaluation — before the app mounts and before any lazily
+// loaded tool chunk can evaluate — which is all that is required.
+import './polyfills/node-globals';
 import 'virtual:uno.css';
 
 registerSW();

--- a/src/polyfills/node-globals.ts
+++ b/src/polyfills/node-globals.ts
@@ -1,0 +1,46 @@
+// Browser polyfills for the Node.js `global` and `process` globals.
+//
+// Several tools depend (transitively) on browserified Node modules — most
+// notably bcryptjs, which pulls in crypto-browserify via the repo-wide
+// `crypto` → `crypto-browserify` alias. Those modules reference `global` and
+// `process` at module-evaluation time. Vite only aliases `global` for its
+// dev-time dependency optimisation (see `optimizeDeps` in vite.config.ts), so
+// the production bundle ships without either, and the first time such a tool's
+// lazily-loaded chunk evaluates it throws `ReferenceError: global is not
+// defined` (then `process is not defined`) and the tool renders blank.
+//
+// main.ts imports this among its eager imports, so both are installed while
+// main.ts evaluates — before the app mounts and before any lazy tool chunk can
+// evaluate. In environments where they already exist (Node, and the Vite dev
+// server) every assignment below is a no-op.
+
+/* eslint-disable node/prefer-global/process -- this module deliberately installs the browser `process` shim */
+
+const globalScope = globalThis as unknown as {
+  global?: unknown;
+  process?: Record<string, unknown>;
+};
+
+if (typeof globalScope.global === 'undefined') {
+  globalScope.global = globalThis;
+}
+
+if (typeof globalScope.process === 'undefined') {
+  globalScope.process = {};
+}
+
+const proc = globalScope.process as Record<string, unknown>;
+
+proc.env ??= {};
+proc.browser ??= true;
+proc.version ??= '';
+proc.versions ??= {};
+proc.platform ??= 'browser';
+proc.title ??= 'browser';
+proc.argv ??= [];
+proc.cwd ??= () => '/';
+proc.nextTick ??= (callback: (...args: unknown[]) => void, ...args: unknown[]) => {
+  // queueMicrotask matches Node's process.nextTick semantics (runs before
+  // timers/promises resolution), which is what the browserified deps expect.
+  queueMicrotask(() => callback(...args));
+};

--- a/src/tools/bcrypt/bcrypt.e2e.spec.ts
+++ b/src/tools/bcrypt/bcrypt.e2e.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Tool - Bcrypt', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/bcrypt');
+  });
+
+  test('Has correct title', async ({ page }) => {
+    await expect(page).toHaveTitle('Bcrypt - IT Tools');
+  });
+
+  test('hashes a string into a well-formed bcrypt hash', async ({ page }) => {
+    // Regression guard: bcryptjs pulls in crypto-browserify, which references
+    // the Node `global`/`process` globals at chunk-eval time. Without the
+    // browser polyfill the tool crashes on load in the production bundle and
+    // renders nothing, so asserting on the rendered hash catches that class of
+    // failure (a title-only check would not).
+    const inputs = page.getByRole('textbox');
+    await inputs.first().fill('hello world');
+
+    const hash = page.locator('input[readonly]').first();
+    await expect(hash).toHaveValue(/^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/);
+  });
+
+  test('reports a matching string and hash', async ({ page }) => {
+    await page.getByRole('textbox').first().fill('hello world');
+
+    const hash = await page.locator('input[readonly]').first().inputValue();
+
+    // Scope to the compare card (its two textboxes: string, then hash) so the
+    // readonly hash output in the first card doesn't shift the indices.
+    const compareCard = page.locator('.c-card').filter({ hasText: 'Compare string with hash' });
+    const compareInputs = compareCard.getByRole('textbox');
+    await compareInputs.nth(0).fill('hello world');
+    await compareInputs.nth(1).fill(hash);
+
+    await expect(page.locator('.compare-result')).toHaveText('Yes');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -160,6 +160,9 @@ export default defineConfig({
         // App wiring, not meaningfully unit-testable
         'src/main.ts',
         'src/plugins/**',
+        // Browser-only Node global shims (global/process); the guarded branches
+        // never execute under Node/jsdom where those globals already exist.
+        'src/polyfills/**',
         // Browser/canvas-only PDF rendering (pdf.js), exercised by e2e
         'src/tools/ocr-image-to-text/ocr-image-to-text.pdf.ts',
         // Trivial browser Map-method shim for pdf.js (branch depends on the


### PR DESCRIPTION
## Summary

Fixes a production-only crash in the **Bcrypt** tool. On the built site (all deploy targets) `/bcrypt` loaded to a **blank page**, throwing `ReferenceError: global is not defined` (then `process is not defined`) in the console.

## Root cause

`bcryptjs` pulls in `crypto-browserify` via the repo-wide `crypto` → `crypto-browserify` alias, and that dependency chain references the Node `global` and `process` globals at **module-evaluation time**. Vite only aliased `global` inside `optimizeDeps.rolldownOptions` — which applies to the **dev-time** dependency prebundle, not the production build. So the production bundle shipped with neither global defined, and the first time bcrypt's lazily-loaded chunk evaluated, it threw and the tool rendered nothing.

This was invisible to existing checks: the dev server has the dev-time alias, and the unit tests run under Node/jsdom where `global`/`process` are real. bcrypt also had **no e2e test**, so Playwright never loaded the page.

## Changes

- **`src/polyfills/node-globals.ts`** (new) — a small, dependency-free shim that installs `globalThis.global` and a minimal `process` object (`env`, `browser`, `version(s)`, `platform`, `title`, `argv`, `cwd`, `nextTick`). Every assignment is guarded, so it's a no-op where those already exist (Node, dev server).
- **`src/main.ts`** — imports the polyfill among the eager imports, so it runs while `main.ts` evaluates, before the app mounts and before any lazy tool chunk can evaluate.
- **`vite.config.ts`** — excludes `src/polyfills/**` from unit coverage (browser-only; its guarded branches never execute under Node/jsdom, matching the existing treatment of the pdf.js browser-only files).
- **`src/tools/bcrypt/bcrypt.e2e.spec.ts`** (new) — loads `/bcrypt` in the production build and asserts a well-formed `$2b$…` hash renders and the compare flow reports a match. A title-only e2e would not have caught a component-mount crash, so this guards the whole "tool crashes on load in the prod bundle" class going forward.

## Testing (thorough)

- Real-browser verification on the **production build**: bcrypt now renders, produces `$2b$10$…` hashes, and the compare card reports **"Yes"** — zero console errors.
- New bcrypt e2e spec: **3/3 pass** against the production build.
- Console-error sweep across all nine Crypto tools: no page errors; every tool renders.
- `pnpm test` (864 unit tests), `pnpm typecheck`, `pnpm lint`, `pnpm build` — all green.

## Notes

- No new dependencies. Pure runtime shim + build-config coverage exclusion.
- This is the follow-up promised in #777, where the crash was first spotted during i18n browser verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_