### PR TITLE
test: guard against i18n key leaks and tool load crashes

### DIFF
--- a/src/app-health.e2e.spec.ts
+++ b/src/app-health.e2e.spec.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test } from '@playwright/test';
+
+// App-wide health crawler. For every tool route it asserts the page mounts in
+// the production bundle with:
+//   - no uncaught page errors (the class of failure that made bcrypt render a
+//     blank page in production while its title-only test stayed green), and
+//   - no unresolved i18n keys leaking as visible `tools.foo.bar` text.
+//
+// Routes are read from each tool's index.ts at load time so this stays in sync
+// as tools are added or their paths change.
+
+const TOOLS_DIR = resolve(import.meta.dirname, 'tools');
+
+function toolRoutes(): { name: string; path: string }[] {
+  return readdirSync(TOOLS_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map((entry) => {
+      const index = resolve(TOOLS_DIR, entry.name, 'index.ts');
+      let source: string;
+      try {
+        source = readFileSync(index, 'utf8');
+      }
+      catch {
+        return undefined;
+      }
+      const path = /path:\s*['"]([^'"]+)['"]/.exec(source)?.[1];
+      return path ? { name: entry.name, path } : undefined;
+    })
+    .filter((r): r is { name: string; path: string } => r !== undefined)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Uncaught errors that are pre-existing and unrelated to a tool's own health
+// can be allowlisted here (with justification). Empty for now.
+const IGNORED_ERROR_PATTERNS: RegExp[] = [];
+
+const RAW_I18N_KEY = /\btools\.[a-z0-9-]+\.[\w.-]+/i;
+
+const routes = toolRoutes();
+
+test.describe('App health - every tool route', () => {
+  for (const { name, path } of routes) {
+    test(`${name} mounts without errors or leaked i18n keys`, async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on('pageerror', err => pageErrors.push(err.message));
+
+      await page.goto(path, { waitUntil: 'networkidle' });
+      // Let the lazily-loaded tool chunk mount and run its initial render.
+      await expect(page.locator('.tool-layout, main').first()).toBeVisible();
+
+      const relevantErrors = pageErrors.filter(
+        message => !IGNORED_ERROR_PATTERNS.some(re => re.test(message)),
+      );
+      expect(relevantErrors, `Uncaught error(s) on ${path}:\n${relevantErrors.join('\n')}`).toEqual([]);
+
+      const bodyText = await page.locator('body').innerText();
+      const leaked = bodyText.match(RAW_I18N_KEY);
+      expect(leaked ?? null, `Raw i18n key leaked on ${path}: ${leaked?.[0]}`).toBeNull();
+    });
+  }
+});

--- a/src/tools/i18n-key-resolution.test.ts
+++ b/src/tools/i18n-key-resolution.test.ts
@@ -1,0 +1,110 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+// Guards against broken i18n references. Every STATIC key passed to t()/$t()/
+// translate() in the source must resolve to a real leaf string in the base
+// locale (locales/en.yml). This catches the class of regression the i18n
+// coverage test cannot see: a renamed, deleted or mistyped in-tool key that
+// would render a raw `tools.foo.bar` string in production while every other
+// test still passes.
+//
+// Only fully-literal, dotted keys are checked. Keys built dynamically
+// (template literals, string concatenation) can't be resolved statically and
+// are skipped by design.
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const SRC = resolve(ROOT, 'src');
+const EN_LOCALE = resolve(ROOT, 'locales/en.yml');
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'node_modules' ? [] : walk(full);
+    }
+    return [full];
+  });
+}
+
+function sourceFiles(): string[] {
+  return walk(SRC).filter(f =>
+    (f.endsWith('.vue') || f.endsWith('.ts'))
+    && !f.endsWith('.d.ts')
+    && !f.endsWith('.test.ts')
+    && !f.endsWith('.spec.ts')
+    && !f.endsWith('.e2e.spec.ts'),
+  );
+}
+
+// Flatten the nested locale object into the set of dotted LEAF keys (keys whose
+// value is a string). A reference to a parent (object) key is therefore treated
+// as unresolved, which is correct — you can't render an object.
+function flattenLeafKeys(obj: unknown, prefix = '', out = new Set<string>()): Set<string> {
+  if (obj && typeof obj === 'object') {
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      const path = prefix ? `${prefix}.${k}` : k;
+      if (typeof v === 'string') {
+        out.add(path);
+      }
+      else {
+        flattenLeafKeys(v, path, out);
+      }
+    }
+  }
+  return out;
+}
+
+// Match the first string-literal argument of t(...) / $t(...) / translate(...).
+// The negative lookbehind avoids matching identifiers that merely end in "t"
+// (e.g. `format(`), and only single/double-quoted literals are captured so
+// template-literal/dynamic keys are ignored.
+const CALL_RE = /(?<![\w$.])(?:\$?t|translate)\(\s*(['"])((?:\\.|(?!\1).)*)\1/g;
+// Only validate things that look like i18n paths: dotted identifiers.
+const KEY_RE = /^[\w-]+(?:\.[\w-]+)+$/;
+
+function keysUsedIn(content: string): string[] {
+  const keys: string[] = [];
+  for (const match of content.matchAll(CALL_RE)) {
+    const key = match[2];
+    if (KEY_RE.test(key)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+describe('i18n key resolution', () => {
+  const enLocale = parse(readFileSync(EN_LOCALE, 'utf8')) ?? {};
+  const leafKeys = flattenLeafKeys(enLocale);
+
+  const references = new Map<string, string[]>(); // key -> files referencing it
+  for (const file of sourceFiles()) {
+    if (statSync(file).isDirectory()) {
+      continue;
+    }
+    const content = readFileSync(file, 'utf8');
+    for (const key of keysUsedIn(content)) {
+      const rel = file.slice(ROOT.length + 1);
+      const list = references.get(key) ?? [];
+      if (!list.includes(rel)) {
+        list.push(rel);
+      }
+      references.set(key, list);
+    }
+  }
+
+  it('resolves every static t()/translate() key against locales/en.yml', () => {
+    const missing = [...references.entries()]
+      .filter(([key]) => !leafKeys.has(key))
+      .map(([key, files]) => `  ${key}  (used in ${files.join(', ')})`);
+
+    expect(
+      missing,
+      missing.length > 0
+        ? `Unresolved i18n keys — add them to locales/en.yml (or fix the reference):\n${missing.join('\n')}`
+        : undefined,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two automated guards for the two failure classes that this project has hit but that **no existing test caught** — they only surfaced during manual browser sweeps. Both now fail CI before merge.

### 1. i18n key-resolution — `src/tools/i18n-key-resolution.test.ts` (unit)

The existing i18n-coverage test only checks that each tool's `title`/`description` exist in `en.yml`. It does **not** verify the in-tool `t('tools.x.y')` keys. After moving ~all UI to i18n, a renamed/deleted/mistyped key would render a raw `tools.foo.bar` string in production with every test still green.

This test scans every `.vue`/`.ts` for static `t()`/`$t()`/`translate()` keys (**1,150+** references) and asserts each resolves to a real **leaf** string in `locales/en.yml`. Runs in ~1s. (Dynamically-built keys — template literals / concatenation — are skipped by design, as they can't be resolved statically.)

### 2. App health crawler — `src/app-health.e2e.spec.ts` (e2e)

One test per tool route (routes read from the `index.ts` files, so it self-syncs as tools change). Each asserts the page mounts in the production bundle with:
- **no uncaught page errors** — the exact class that made **bcrypt** render a blank page in production while its title-only test stayed green, and
- **no leaked `tools.*` i18n keys** visible on load.

## Testing

- New unit test passes and is proven to have teeth (mutation-tested: breaking one key fails it, restoring passes).
- Crawler: **all 100 routes pass** locally against the `pnpm build` production preview — zero uncaught errors, zero key leaks.
- Full unit suite green (865 tests); `pnpm lint` clean.
- Tests only — no source changes.

## Notes

- The crawler asserts on **uncaught** `pageerror` (real crashes), not `console.error`, to avoid flagging benign third-party console noise (e.g. Monaco worker warnings). A documented allowlist is available if a genuine, out-of-scope pre-existing error ever needs to be tolerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5GcerGwP2BTLi3u8QpRY3)_