### PR TITLE
test(e2e): adopt Playwright 1.62 isolated retry strategy

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
   forbidOnly: isCI,
   /* Retry on CI only */
   retries: isCI ? 2 : 0,
+  /* Defer retries to the end and run them one-by-one in a single worker, so a
+     retry reflects the test itself rather than contention with the parallel
+     suite (Playwright >= 1.62). Inert when retries is 0. */
+  retryStrategy: 'isolated',
   /* On CI use most of the runner's cores per shard (GitHub ubuntu runners have
    * 4); locally let Playwright pick. Expressed as a percentage so it scales if
    * the runner size changes. */


### PR DESCRIPTION
### Description

Now that #787 landed `@playwright/test` 1.62.0, this adopts the one new feature that concretely helps our E2E setup: **`retryStrategy: 'isolated'`**.

Our `playwright.config.ts` runs `fullyParallel: true` with `workers: 2` per shard and `retries: 2` on CI. The default `'immediate'` strategy retries a failed test right away inside the still-busy parallel pool, so a flaky retry can reflect contention with concurrent tests rather than the test itself. `'isolated'` (new in 1.62) defers all retries to the end and runs them one-by-one in a single worker, so a retry is a cleaner pass/fail signal. It's inert when `retries` is 0, so local runs are unaffected.

```ts
retries: isCI ? 2 : 0,
retryStrategy: 'isolated', // <- added
workers: isCI ? 2 : undefined,
```

### Verification

- `pnpm exec playwright test --list` resolves the config under 1.62.0 with the new option accepted (349 tests, exit 0).
- `pnpm lint` clean on the changed file.

No behavior change to the tests themselves — only how retries are scheduled on CI.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (CI/test-infra tuning)

### Before submitting the PR, please make sure you do the following

- [x] Submit the PR against the default branch (`main`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. *(N/A — CI-only retry-scheduling config; validated via `playwright test --list`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb)_