### PR TITLE
test(e2e): activate the visual-regression pilot

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:unit": "vitest --environment jsdom --run",
     "test:e2e": "playwright test",
     "test:e2e:dev": "BASE_URL=http://localhost:5173 NO_WEB_SERVER=true playwright test",
-    "test:e2e:visual": "VISUAL=1 playwright test src/visual-regression.e2e.spec.ts --project=chromium",
+    "test:e2e:visual": "playwright test src/visual-regression.e2e.spec.ts --project=chromium",
     "coverage": "vitest run --coverage --environment jsdom",
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint src scripts worker *.ts *.mjs --no-warn-ignored",

--- a/src/visual-regression.e2e.spec.ts
+++ b/src/visual-regression.e2e.spec.ts
@@ -8,13 +8,9 @@ import { expect, test } from '@playwright/test';
 // excludes the sidebar — the sidebar carries date-based "new" badges that would
 // make full-page snapshots drift over time.
 test.describe('Visual regression', () => {
-  // Opt-in pilot. Golden snapshots are Chromium- and version-specific, so they
-  // must be (re)generated on the same browser CI uses before this is wired into
-  // the pipeline. Until then it stays off the default e2e run so it can't red CI.
-  //   pnpm test:e2e:visual                     # compare against goldens
-  //   pnpm test:e2e:visual --update-snapshots  # refresh goldens on this browser
-  test.skip(!process.env.VISUAL, 'Set VISUAL=1 to run the visual-regression pilot');
-  test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium goldens only (pilot)');
+  // Goldens are maintained for Chromium only (the browser Playwright pins for
+  // this project); refresh them with `pnpm test:e2e:visual --update-snapshots`.
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium goldens only');
 
   async function waitForStableRender(page: import('@playwright/test').Page) {
     // Ensure web fonts are loaded so text metrics are stable before snapshotting.


### PR DESCRIPTION
### Description

Follow-up to #792, which shipped the visual-regression mechanism **gated behind `VISUAL=1`** because the build environment only had Chromium 141 while CI's Playwright 1.62 uses Chromium 151 — so the goldens couldn't be verified against CI's actual browser.

That version gap is now closed. The matching **Chromium 151.0.7922.34** (Playwright build 1234) was installed and the goldens regenerated on it — they came out **byte-identical to the ones already committed in #792** (git showed no change), confirming those goldens match Chromium 151 rendering.

So this activates the pilot:
- Remove the `VISUAL=1` gate so the two visual checks run as part of the normal e2e job on **Chromium** (Firefox/WebKit still skip — Chromium-only goldens).
- Drop the now-inert `VISUAL=1` from the `test:e2e:visual` script.

No golden files change — they were already correct on `main`.

### Verification (local, on Chromium 151 matching CI)
- Visual specs **run** (not skip) on chromium and pass against the committed goldens ✅
- Firefox/WebKit still skip ✅
- `pnpm lint` clean ✅

Any real failure now surfaces in the unified HTML report (from #792) with actual/expected/diff attached. The one residual variable I can't verify from here is the CI runner's font environment vs the sandbox's (both Ubuntu 24.04 + Chromium 151, and there's a 2% pixel tolerance) — I'm watching the CI run and will adjust tolerance / refresh goldens if the first run surfaces a rendering delta.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (activate E2E visual-regression checks)

### Before submitting the PR, please make sure you do the following

- [x] Submit the PR against the default branch (`main`).
- [x] Check that there isn't already a PR that solves the problem the same way.
- [x] Provide a description that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. *(Activates existing visual specs.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb)_