### PR TITLE
fix: correct overly permissive regex range in token-generator test

### DIFF
--- a/src/tools/token-generator/token-generator.service.test.ts
+++ b/src/tools/token-generator/token-generator.service.test.ts
@@ -79,7 +79,7 @@ describe('token-generator', () => {
       });
 
       expect(token).toHaveLength(256);
-      expect(token).toMatch(/^[.,;:!?/\-"'#([-|@)=}*+]+$/);
+      expect(token).toMatch(/^[.,;:!?/\-"'#{([|\\@)\]=}*+]+$/);
     });
 
     it('should generate a random string with just letters (case incensitive) with withLowercase and withUppercase', () => {


### PR DESCRIPTION
### Description

Fixes the CodeQL `js/overly-large-range` alert (#14) in `src/tools/token-generator/token-generator.service.test.ts`.

The symbols assertion used the character class `[.,;:!?/\-"'#([-|@)=}*+]`. The fragment `[-|` was interpreted as a **range** from `[` (0x5B) to `|` (0x7C), so instead of matching a literal `[`, `-`, and `|`, it silently matched the entire span `[ \ ] ^ _ ` a-z {`. The test still passed only because that over-broad range happened to cover the real symbol characters.

The fix rewrites the character class to enumerate exactly the symbols produced by `createToken`'s alphabet (`.,;:!?/-"'#{([|\@)]=}*+`), with `-`, `]`, and `\` properly escaped so they are treated as literals:

```
/^[.,;:!?/\-"'#{([|\\@)\]=}*+]+$/
```

I verified the corrected regex matches every symbol in the generator's alphabet and now correctly rejects the previously over-matched characters (`a-z`, `^`, `_`, `` ` ``). Unit tests (8) and ESLint pass.

### Additional context

This is a test-only change; the tool's runtime behavior is unaffected. The stricter assertion also makes the test a genuine guard against unexpected characters appearing in the symbol alphabet.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166kgjhgystwDVWw9V1UJRs

---
_Generated by [Claude Code](https://claude.ai/code/session_0166kgjhgystwDVWw9V1UJRs)_