### PR TITLE
test(unit): close logic-layer branch-coverage gap (93.99% → 96.46%)

### DIFF
--- a/src/composable/queryParams.test.ts
+++ b/src/composable/queryParams.test.ts
@@ -99,6 +99,19 @@ describe('useQueryParam', () => {
     expect(result.value).toBe(5);
     wrapper.unmount();
   });
+
+  it('falls back to the string transformer for an unmapped default value type', async () => {
+    // `typeof undefined` is 'undefined', which is not one of the mapped
+    // transformer keys, so the string (identity) transformer is used and the
+    // raw query string is returned unchanged.
+    const { result, wrapper } = await withSetup(
+      () => useQueryParam<string>({ name: 'q', defaultValue: undefined as unknown as string }),
+      { initialQuery: { q: 'raw-string' } },
+    );
+
+    expect(result.value).toBe('raw-string');
+    wrapper.unmount();
+  });
 });
 
 describe('useQueryParamOrStorage', () => {
@@ -162,6 +175,19 @@ describe('useQueryParamOrStorage', () => {
     );
 
     expect(result.value).toBe(33);
+    wrapper.unmount();
+  });
+
+  it('falls back to the string transformer for an unmapped default value type', async () => {
+    // `typeof undefined` is 'undefined', which is not one of the mapped
+    // transformer keys, so the string (identity) transformer is used and the
+    // raw query string is returned unchanged.
+    const { result, wrapper } = await withSetup(
+      () => useQueryParamOrStorage<string>({ name: 'p', storageName: 'test-storage-f', defaultValue: undefined as unknown as string }),
+      { initialQuery: { p: 'raw-string' } },
+    );
+
+    expect(result.value).toBe('raw-string');
     wrapper.unmount();
   });
 });

--- a/src/tools/ascii-text-drawer/ascii-text-drawer.service.test.ts
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.service.test.ts
@@ -1,12 +1,16 @@
 import figlet from 'figlet';
 import standardFontData from 'figlet/importable-fonts/Standard.js';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { drawAsciiArtText } from './ascii-text-drawer.service';
 
 describe('ascii-text-drawer', () => {
   beforeAll(() => {
     // Preload the font from the figlet package so tests do not depend on network or filesystem font loading
     figlet.parseFont('Standard', standardFontData);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('drawAsciiArtText', () => {
@@ -48,6 +52,22 @@ describe('ascii-text-drawer', () => {
       await expect(
         drawAsciiArtText({ text: 'Hi', font: 'ThisFontDoesNotExist', width: 80 }),
       ).rejects.toThrow();
+    });
+
+    it('resolves to an empty string when figlet yields no text', async () => {
+      // figlet types the callback result as optional (string | undefined); when
+      // it reports success without any drawn text, the service falls back to ''.
+      vi.spyOn(figlet, 'text').mockImplementation(((
+        _text: string,
+        _options: unknown,
+        callback: (error: Error | null, drawnText?: string) => void,
+      ) => {
+        callback(null, undefined);
+      }) as unknown as typeof figlet.text);
+
+      const drawn = await drawAsciiArtText({ text: 'Hi', font: 'Standard', width: 80 });
+
+      expect(drawn).toBe('');
     });
   });
 });

--- a/src/tools/bip39-generator/bip39-generator.service.test.ts
+++ b/src/tools/bip39-generator/bip39-generator.service.test.ts
@@ -62,6 +62,18 @@ describe('bip39-generator', () => {
     it('throws for an invalid entropy', () => {
       expect(() => convertEntropyToMnemonic({ entropy: 'abcd', language: 'English' })).toThrow();
     });
+
+    it('throws for an entropy longer than 32 characters', () => {
+      expect(() => convertEntropyToMnemonic({ entropy: 'a'.repeat(36), language: 'English' })).toThrow('should be <= 32');
+    });
+
+    it('throws for an entropy length that is not a multiple of 4', () => {
+      expect(() => convertEntropyToMnemonic({ entropy: 'a'.repeat(18), language: 'English' })).toThrow('multiple of 4');
+    });
+
+    it('throws for a valid-length entropy that is not hexadecimal', () => {
+      expect(() => convertEntropyToMnemonic({ entropy: '!'.repeat(16), language: 'English' })).toThrow('hexadecimal');
+    });
   });
 
   describe('convertMnemonicToEntropy', () => {
@@ -85,6 +97,12 @@ describe('bip39-generator', () => {
 
     it('throws for a mnemonic with words outside of the word list', () => {
       expect(() => convertMnemonicToEntropy({ mnemonic: 'not a valid mnemonic', language: 'English' })).toThrow();
+    });
+
+    it('throws for a mnemonic too short to carry any entropy bits', () => {
+      // A single word yields 11 bits (< 33), so the entropy slice is empty (the
+      // 8-bit match returns no chunks) and the checksum cannot match.
+      expect(() => convertMnemonicToEntropy({ mnemonic: 'abandon', language: 'English' })).toThrow();
     });
   });
 

--- a/src/tools/csv-to-json/csv-to-json.service.test.ts
+++ b/src/tools/csv-to-json/csv-to-json.service.test.ts
@@ -29,6 +29,10 @@ describe('csv-to-json', () => {
       expect(parseCsv('a,b\r\n1,2\r\n3,4')).toEqual([['a', 'b'], ['1', '2'], ['3', '4']]);
     });
 
+    it('handles lone CR (classic Mac) line endings', () => {
+      expect(parseCsv('a,b\r1,2\r3,4')).toEqual([['a', 'b'], ['1', '2'], ['3', '4']]);
+    });
+
     it('supports a custom delimiter', () => {
       expect(parseCsv('a;b\n1;2', { delimiter: ';' })).toEqual([['a', 'b'], ['1', '2']]);
     });

--- a/src/tools/data-storage-converter/data-storage-converter.service.test.ts
+++ b/src/tools/data-storage-converter/data-storage-converter.service.test.ts
@@ -28,5 +28,9 @@ describe('data-storage-converter', () => {
     it('throws on an unknown unit', () => {
       expect(() => convertDataSize({ value: 1, from: 'byte', to: 'furlong' })).toThrow('Unknown data unit: furlong');
     });
+
+    it('throws naming the source unit when it is unknown', () => {
+      expect(() => convertDataSize({ value: 1, from: 'furlong', to: 'byte' })).toThrow('Unknown data unit: furlong');
+    });
   });
 });

--- a/src/tools/integer-base-converter/integer-base-converter.model.test.ts
+++ b/src/tools/integer-base-converter/integer-base-converter.model.test.ts
@@ -16,5 +16,12 @@ describe('integer-base-converter', () => {
         expect(convertBase({ value: '20010db8000085a300000000ac1f8908', fromBase: 16, toBase: 10 })).toEqual('42540766411283223938465490632011909384');
       });
     });
+
+    describe('when the value contains a digit outside the source base', () => {
+      it('should throw an explicit error naming the invalid digit and base', () => {
+        expect(() => convertBase({ value: '9', fromBase: 2, toBase: 10 })).toThrow('Invalid digit "9" for base 2.');
+        expect(() => convertBase({ value: 'g', fromBase: 16, toBase: 10 })).toThrow('Invalid digit "g" for base 16.');
+      });
+    });
   });
 });

--- a/src/tools/meta-tag-generator/oggen.test.ts
+++ b/src/tools/meta-tag-generator/oggen.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { generateMeta } from './oggen';
+
+describe('oggen', () => {
+  describe('generateMeta', () => {
+    it('does not emit twitter-compatible fallbacks when the option is disabled (default)', () => {
+      const result = generateMeta({ title: 'T', twitter: { card: 'summary' } });
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og:title" content="T" />',
+        '',
+        '<!-- twitter meta -->',
+        '<meta name="twitter:card" content="summary" />',
+      ].join('\n'));
+      expect(result).not.toContain('twitter:title');
+    });
+
+    it('emits twitter-compatible fallbacks from og values when the option is enabled', () => {
+      const result = generateMeta({ title: 'My title', twitter: { card: 'summary' } }, { generateTwitterCompatibleMeta: true });
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og:title" content="My title" />',
+        '',
+        '<!-- twitter meta -->',
+        '<meta name="twitter:card" content="summary" />',
+        '<meta name="twitter:title" content="My title" />',
+      ].join('\n'));
+    });
+
+    it('skips undefined and empty-string values', () => {
+      // Optional schema fields can reach oggen as `undefined` at runtime even
+      // though the direct-call signature doesn't model it; cast to exercise the
+      // undefined/empty-string skip guard.
+      const result = generateMeta({ a: undefined, b: '', c: 'yes' } as unknown as Parameters<typeof generateMeta>[0]);
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og:c" content="yes" />',
+      ].join('\n'));
+    });
+
+    it('flattens array values into repeated meta tags', () => {
+      const result = generateMeta({ image: ['x', 'y'] });
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og:image" content="x" />',
+        '<meta property="og:image" content="y" />',
+      ].join('\n'));
+    });
+
+    it('serialises Date values as ISO strings', () => {
+      const result = generateMeta({ published: new Date('2020-01-02T03:04:05.000Z') });
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og:published" content="2020-01-02T03:04:05.000Z" />',
+      ].join('\n'));
+    });
+
+    it('falls back to an empty segment for keys with no snake-case-able characters', () => {
+      const result = generateMeta({ '!!': 'v' });
+
+      expect(result).toBe([
+        '<!-- og meta -->',
+        '<meta property="og" content="v" />',
+      ].join('\n'));
+    });
+  });
+});

--- a/src/tools/regex-tester/regex-tester.service.test.ts
+++ b/src/tools/regex-tester/regex-tester.service.test.ts
@@ -92,6 +92,36 @@ const regexesData = [
       },
     ],
   },
+  {
+    // Optional numbered and named groups that don't participate in the match
+    // exercise the non-participating-capture branches (undefined indices are
+    // skipped for both numbered captures and named groups).
+    regex: '(?<x>a)(?<y>b)?c',
+    text: 'ac',
+    flags: 'g',
+    result: [
+      {
+        captures: [
+          {
+            end: 1,
+            name: '1',
+            start: 0,
+            value: 'a',
+          },
+        ],
+        groups: [
+          {
+            end: 1,
+            name: 'x',
+            start: 0,
+            value: 'a',
+          },
+        ],
+        index: 0,
+        value: 'ac',
+      },
+    ],
+  },
 ];
 
 describe('regex-tester', () => {

--- a/src/tools/string-obfuscator/string-obfuscator.model.test.ts
+++ b/src/tools/string-obfuscator/string-obfuscator.model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { obfuscateString } from './string-obfuscator.model';
+import { obfuscateString, useObfuscateString } from './string-obfuscator.model';
 
 describe('string-obfuscator model', () => {
   describe('obfuscateString', () => {
@@ -15,6 +15,20 @@ describe('string-obfuscator model', () => {
     it('by default, the spaces are kept, they can be removed with the keepSpace option', () => {
       expect(obfuscateString('12345 67890')).toBe('1234* *****');
       expect(obfuscateString('12345 67890', { keepSpace: false })).toBe('1234*******');
+    });
+  });
+
+  describe('useObfuscateString', () => {
+    it('obfuscates using the default options when the config argument is omitted', () => {
+      const result = useObfuscateString('1234567890');
+
+      expect(result.value).toBe('1234******');
+    });
+
+    it('unwraps the provided reactive config options', () => {
+      const result = useObfuscateString('1234567890', { keepFirst: 2, keepLast: 2, replacementChar: 'x' });
+
+      expect(result.value).toBe('12xxxxxx90');
     });
   });
 });

--- a/src/tools/text-line-tools/text-line-tools.service.test.ts
+++ b/src/tools/text-line-tools/text-line-tools.service.test.ts
@@ -70,5 +70,12 @@ describe('text-line-tools', () => {
       // A shuffle keeps the same set of lines.
       expect(first.split('\n').sort()).toEqual(input.split('\n').sort());
     });
+
+    it('shuffles deterministically when an empty line makes the seed fall back to 1', () => {
+      // A leading empty line makes charCodeAt(0) NaN, so the computed seed is
+      // NaN and the `|| 1` fallback kicks in. The result is still deterministic.
+      const input = '\na\nb\nc';
+      expect(applyLineOperations(input, { ...noOps, sort: 'shuffle' })).toBe('c\na\n\nb');
+    });
   });
 });

--- a/src/tools/uuid-generator/uuid-generator.service.test.ts
+++ b/src/tools/uuid-generator/uuid-generator.service.test.ts
@@ -1,3 +1,4 @@
+import type { UuidVersion } from './uuid-generator.service';
 import { describe, expect, it } from 'vitest';
 import { generateUuids, isValidUuid, uuidVersions } from './uuid-generator.service';
 
@@ -100,6 +101,13 @@ describe('uuid-generator', () => {
       }
 
       expect(new Set(uuids).size).toBe(50);
+    });
+
+    it('falls back to the nil uuid for an unknown version', () => {
+      expect(generateUuids({ version: 'v9' as UuidVersion, count: 2 })).toEqual([
+        '00000000-0000-0000-0000-000000000000',
+        '00000000-0000-0000-0000-000000000000',
+      ]);
     });
 
     it('throws when generating a v3 or v5 uuid with an invalid namespace', () => {

--- a/src/utils/random.test.ts
+++ b/src/utils/random.test.ts
@@ -93,6 +93,12 @@ describe('random utils', () => {
       vi.spyOn(Math, 'random').mockReturnValue(0);
       expect(shuffleArrayMutate([1, 2, 3])).toEqual([2, 3, 1]);
     });
+
+    it('leaves a pair untouched when an element is undefined', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      // i=1, j=0: temp=array[1]=undefined, so the swap guard is skipped.
+      expect(shuffleArrayMutate([1, undefined])).toEqual([1, undefined]);
+    });
   });
 
   describe('shuffleArray', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -182,10 +182,10 @@ export default defineConfig({
       // get locked in as the new floor. Commit the bumped values.
       thresholds: {
         autoUpdate: true,
-        lines: 97.06,
-        statements: 97.06,
-        functions: 98.58,
-        branches: 93.99,
+        lines: 97.7,
+        statements: 97.73,
+        functions: 98.98,
+        branches: 96.46,
       },
     },
   },


### PR DESCRIPTION
### Description

Closes the branch-coverage gap in the logic layer. Unit coverage tracked ~94% branches vs ~97% lines — that spread was **uncovered branches**: error paths, guard clauses, and one-sided ternaries. This adds targeted unit tests for the **reachable** ones, lifting branches **93.99% → 96.46%** (798 → 819 of 849) and ratcheting the no-regression thresholds accordingly (lines 97.7, statements 97.73, functions 98.98, branches 96.46).

Every added test asserts **real behavior** — expected values are derived from the code, not lazy truthy checks:

| File | Branch covered |
|---|---|
| `bip39-generator/bip39` | entropy length/format guards + empty-bits fallback |
| `uuid-generator` | unknown-version → NIL fallback |
| `utils/random` | undefined-element swap guard |
| `meta-tag-generator/oggen` | twitter-compat off · undefined/empty skip · array flatten · Date→ISO · non-snakecase key |
| `regex-tester` | non-participating numbered/named capture groups |
| `csv-to-json` | lone-CR (classic-Mac) line ending |
| `data-storage-converter` | unknown `from` unit error |
| `text-line-tools` | empty-line seed fallback in shuffle |
| `integer-base-converter` | invalid-digit-for-base error |
| `string-obfuscator` | default-config path of `useObfuscateString` |
| `ascii-text-drawer` | figlet undefined-result fallback |
| `composable/queryParams` | unmapped-type → string transformer fallback |

**On the branches left uncovered:** the remainder are defensive guards that are **genuinely unreachable through the public API** — typed-array element reads (`buffer[0] ?? 0`), `.match()` on guaranteed-format strings, `mime-types` returning `false` (not `undefined`), HMAC digest-length invariants. These were verified empirically and left **unforced** rather than papered over with contrived `as any` inputs, which would assert an impossible contract rather than real behavior.

### Verification

- `pnpm test` — 1107 passed (119 files) ✅
- `pnpm coverage` — branches 96.46% (819/849), thresholds auto-ratcheted ✅
- `pnpm typecheck` / `pnpm lint` — clean ✅

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other (unit test coverage)

### Before submitting the PR, please make sure you do the following

- [x] Submit the PR against the default branch (`main`).
- [x] Check that there isn't already a PR that solves the problem the same way.
- [x] Provide a description that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it. *(This PR is entirely such tests.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2tH7NeVppR2gAgqYgNUpb)_