### PR TITLE
fix: allow-list JWT parser example token in Trivy secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,12 @@ jobs:
       # The blocking gate below is what actually fails the build.
       - name: Trivy full audit (SARIF)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # Allow-list the JWT parser tool's public example-token placeholder so
+          # the jwt-token secret rule doesn't flag it in the built bundle. The
+          # `--severity` filter does not apply to secret findings, hence the
+          # config-level allow-rule. See trivy-secret.yaml.
+          TRIVY_SECRET_CONFIG: trivy-secret.yaml
         with:
           image-ref: it-tools:${{ matrix.target }}
           severity: 'HIGH,CRITICAL'
@@ -473,6 +479,10 @@ jobs:
       # image rebuild or base-image bump can actually resolve.
       - name: Scan image with Trivy (fails on fixable HIGH/CRITICAL)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # Same allow-list as the audit step above, so a secret finding can
+          # never trip this gate either. See trivy-secret.yaml.
+          TRIVY_SECRET_CONFIG: trivy-secret.yaml
         with:
           image-ref: it-tools:${{ matrix.target }}
           severity: 'HIGH,CRITICAL'

--- a/src/tools/jwt-parser/jwt-parser.vue
+++ b/src/tools/jwt-parser/jwt-parser.vue
@@ -6,6 +6,11 @@ import { decodeJwt } from './jwt-parser.service';
 
 const { t } = useI18n();
 
+// Public jwt.io example token used as a placeholder so the tool shows a decoded
+// result out of the box. It decodes to {"sub":"1234567890","name":"John Doe",
+// "iat":1516239022} signed with the public sample secret "your-256-bit-secret" -
+// not a real credential. It is allow-listed in trivy-secret.yaml so the secret
+// scanner doesn't flag it in the built bundle.
 const rawJwt = ref(
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
 );

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,0 +1,18 @@
+# Trivy secret-scanning configuration.
+# https://trivy.dev/latest/docs/scanner/secret/
+#
+# Allow-list the single well-known public JWT that the JWT parser tool ships as
+# its input placeholder (src/tools/jwt-parser/jwt-parser.vue). It is the
+# canonical jwt.io example token: it decodes to
+#   header  {"alg":"HS256","typ":"JWT"}
+#   payload {"sub":"1234567890","name":"John Doe","iat":1516239022}
+# and is signed with the public sample secret "your-256-bit-secret". It carries
+# no real credential, so Trivy's `jwt-token` rule flagging it in the built bundle
+# (e.g. public/assets/jwt-parser-*.js) is a false positive.
+#
+# The allow-rule matches only this exact token, so the `jwt-token` rule stays
+# fully active for any genuinely leaked JWT.
+allow-rules:
+  - id: jwt-parser-example-token
+    description: Public jwt.io example JWT used as the JWT parser tool's placeholder input
+    regex: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c


### PR DESCRIPTION
### Description

Clears the Trivy **"JWT token"** secret-scanning alert (#82, rule `jwt-token`) reported against the built bundle `public/assets/jwt-parser-*.js`.

**This is a false positive.** The flagged string is the canonical public **jwt.io example token** that the JWT parser tool hardcodes as its input placeholder (`src/tools/jwt-parser/jwt-parser.vue`). It decodes to:

- header: `{"alg":"HS256","typ":"JWT"}`
- payload: `{"sub":"1234567890","name":"John Doe","iat":1516239022}`

and its signature is computed with the well-known public sample secret `your-256-bit-secret`. It is a documentation placeholder, **not a real credential**.

**Fix:** add a `trivy-secret.yaml` allow-rule that matches *only this exact token*, and wire it into both Trivy steps of the `docker-image` CI job via `TRIVY_SECRET_CONFIG`. Because Trivy's `--severity` filter does **not** apply to secret findings (which is why a MEDIUM secret reached the Security tab despite the `HIGH,CRITICAL` filter), a config-level allow-rule is the correct suppression mechanism. The `jwt-token` rule stays fully active for any genuinely leaked JWT — I verified the rule regex matches this token (in a minified-bundle context) but rejects a different JWT.

Also added a short comment in `jwt-parser.vue` documenting the placeholder's provenance and its allow-listing, so a future maintainer isn't surprised.

### Additional context

- The `docker-image` CI job is gated to Docker/CI changes; editing `ci.yml` deliberately triggers it on this PR, so the Trivy scan runs here and the reviewer can confirm the finding no longer appears.
- No change to tool behavior — the tool still shows the decoded example JWT out of the box.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166kgjhgystwDVWw9V1UJRs

---
_Generated by [Claude Code](https://claude.ai/code/session_0166kgjhgystwDVWw9V1UJRs)_