### PR TITLE
fix(ascii-text-drawer): drop trailing slash from figlet fontPath (404 on R2)

### DIFF
--- a/src/tools/ascii-text-drawer/ascii-text-drawer.vue
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.vue
@@ -24,11 +24,16 @@ const processing = ref(false);
 // asset host; dev/offline builds serve same-origin from public/figlet (populated
 // by `pnpm script:figlet:fonts`). An explicit VITE_FIGLET_ASSETS_BASE_URL
 // override always wins - that origin must then be allowed by the CSP.
+//
+// The fontPath must NOT end in a slash: figlet builds the request as
+// `${fontPath}/${fontName}.flf`, so a trailing slash yields `fonts//Name.flf`,
+// a double slash that R2 serves as a distinct (missing) key -> 404 -> the tool
+// errors. Keeping no trailing slash produces the correct `fonts/Name.flf`.
 const figletAssetsBase = (
   import.meta.env.VITE_FIGLET_ASSETS_BASE_URL
     ?? (import.meta.env.PROD ? 'https://assets.thetech.network' : '')
 ).replace(/\/+$/, '');
-figlet.defaults({ fontPath: `${figletAssetsBase}/figlet/${import.meta.env.FIGLET_VERSION}/fonts/` });
+figlet.defaults({ fontPath: `${figletAssetsBase}/figlet/${import.meta.env.FIGLET_VERSION}/fonts` });
 
 watchEffect(async () => {
   processing.value = true;


### PR DESCRIPTION
### Description

The ASCII Art Text Generator showed **"Current settings resulted in error"** on the deployed site — no font would load.

Root cause: figlet builds its font request as `` `${fontPath}/${fontName}.flf` `` — it inserts its **own** slash. Our `fontPath` ended in a slash (`…/figlet/<v>/fonts/`), so the browser actually requested `…/figlet/<v>/fonts//<Name>.flf` — a **double slash**, which R2 serves as a distinct, missing key → **404** → every font failed and the tool errored.

The old unpkg URL also had a trailing slash, but unpkg normalises the double slash; R2 does not. Removing the trailing slash yields the correct single-slash `fonts/<Name>.flf`.

**Verified against R2:**
- `…/figlet/1.11.4/fonts/3D-ASCII.flf` → **200**
- `…/figlet/1.11.4/fonts//3D-ASCII.flf` (double slash) → **404**

And the rebuilt chunk now emits the path literal as `/figlet/1.11.4/fonts` (no trailing slash).

### Additional context

- This is the browser-only failure mode my earlier server-side checks (curl + Node figlet render) couldn't surface — both used the correct single-slash URL and never exercised figlet's client-side URL construction. Caught via a screenshot of the live site.
- One-line change; `typecheck`, `lint`, and `build` all pass.

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_