### PR TITLE
ci: raise Playwright system-deps install timeouts for slow apt mirrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,15 @@ jobs:
       - name: Install Playwright browser and system dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
-        timeout-minutes: 5
+        timeout-minutes: 12
 
+      # `install-deps` is an apt install of the browser's system libraries; it
+      # occasionally crawls on a slow Ubuntu mirror. Generous timeout so a
+      # slow-but-progressing download finishes instead of tripping the cap.
       - name: Install Playwright system dependencies only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps ${{ matrix.project }}
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       # Functional e2e only — the visual-regression spec is excluded here and
       # owned by visual-regression-goldens.yml (which validates + creates goldens

--- a/.github/workflows/visual-regression-goldens.yml
+++ b/.github/workflows/visual-regression-goldens.yml
@@ -207,12 +207,15 @@ jobs:
       - name: Install Playwright browser and system dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
-        timeout-minutes: 5
+        timeout-minutes: 12
 
+      # `install-deps` is an apt install of the browser's system libraries; it
+      # occasionally crawls on a slow Ubuntu mirror. Generous timeout so a
+      # slow-but-progressing download finishes instead of tripping the cap.
       - name: Install Playwright system dependencies only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps ${{ matrix.project }}
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/visual-regression-update.yml
+++ b/.github/workflows/visual-regression-update.yml
@@ -90,12 +90,15 @@ jobs:
       - name: Install Playwright browser and system dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
-        timeout-minutes: 5
+        timeout-minutes: 12
 
+      # `install-deps` is an apt install of the browser's system libraries; it
+      # occasionally crawls on a slow Ubuntu mirror. Generous timeout so a
+      # slow-but-progressing download finishes instead of tripping the cap.
       - name: Install Playwright system dependencies only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps ${{ matrix.project }}
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
### Description

Intermittent CI flake, not a code failure: the **`playwright install-deps`** step (an `apt-get` install of a browser's system libraries — GTK, GStreamer, etc.) occasionally **crawls on a slow Ubuntu mirror** and overruns its 10-minute cap, so an e2e or visual-regression **leg fails before any test runs**. It's hit twice recently (a Firefox e2e leg and a WebKit `goldens` leg), each time timing out mid-download while the install was still *progressing*.

Since the download was progressing (not stuck), the fix is simply a more generous cap so it can finish:

| Step | before | after |
|---|---|---|
| `playwright install-deps <project>` (cache hit) | 10 min | **20 min** |
| `playwright install --with-deps <project>` (cache miss) | 5 min | **12 min** |

Applied consistently across the three workflows that install Playwright browsers: `ci.yml`, `visual-regression-goldens.yml`, and `visual-regression-update.yml`. Added a one-line comment at the step explaining why the cap is generous.

No behavior change beyond the timeout ceiling — a healthy install (the normal ~1-2 min case) is unaffected; only a pathologically slow mirror now gets the extra headroom instead of failing the leg.

### 🧪 How to test

Nothing to run — it's a timeout ceiling. `actionlint` covers the workflow syntax. The effect is observable only when a runner hits a slow apt mirror (the leg now completes instead of erroring at 10 min).

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_