### PR TITLE
chore(renovate): stop flagging the BIP39 wordlist's ideographic space

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
   "labels": ["dependencies"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "src/tools/bip39-generator/wordlists.ts"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
### Description

Renovate warns on each run that `src/tools/bip39-generator/wordlists.ts` contains a hidden Unicode character (` `). That character is **legitimate**: it's a single **ideographic space (U+3000)**, the `spacer` value for the **Japanese** BIP39 wordlist. Per the BIP39 spec, Japanese mnemonics are joined with U+3000 rather than an ASCII space, and `bip39.ts` uses it via `.join(spacer)` / `.split(spacer)`. A full sweep of the file found **no** dangerous characters (no zero-width, bidi overrides, or BOM) — it's spec-required data, not smuggled text.

The reason Renovate even reads this file is the `customManagers` guardrail, whose file pattern matches all `.ts`/`.vue` files (to catch `// renovate:` version annotations). This adds the one file to `ignorePaths` so Renovate skips it and stops warning. RE2 (Renovate's regex engine) has no negative lookahead, so the manager's glob can't be negated — `ignorePaths` is the supported mechanism.

Note: `ignorePaths` **replaces** the preset default rather than merging, so the `node_modules` / `bower_components` defaults are re-listed. This repo has a single root `package.json`, so no dependency scanning is affected.

### 🧪 How to test

- `renovate.json` remains valid (schema-valid JSON).
- On the next Renovate run, the "Hidden Unicode characters" warning for `wordlists.ts` no longer appears; dependency updates are otherwise unaffected.

### Additional context

The wordlist data itself is unchanged — the character stays U+3000, because Japanese BIP39 phrases require it.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other (CI/tooling configuration)

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_