### PR TITLE
refactor: migrate the hashing tools from deprecated crypto-js to @noble/hashes

### DIFF
--- a/src/tools/hash-text/hash-text.service.ts
+++ b/src/tools/hash-text/hash-text.service.ts
@@ -1,7 +1,35 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
+
+export type Encoding = 'Bin' | 'Hex' | 'Base64' | 'Base64url';
+
 export function convertHexToBin(hex: string) {
   return hex
     .trim()
     .split('')
     .map(byte => Number.parseInt(byte, 16).toString(2).padStart(4, '0'))
     .join('');
+}
+
+// Renders a raw digest (as produced by @noble/hashes) in the encoding the UI
+// offers. Matches the output crypto-js produced for the same encodings, so the
+// hash/HMAC tools keep identical results after dropping crypto-js: lowercase
+// hex, standard padded Base64, and URL-safe Base64 without padding.
+export function formatBytes(bytes: Uint8Array, encoding: Encoding): string {
+  if (encoding === 'Hex') {
+    return bytesToHex(bytes);
+  }
+
+  if (encoding === 'Bin') {
+    return convertHexToBin(bytesToHex(bytes));
+  }
+
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64 = btoa(binary);
+
+  return encoding === 'Base64url'
+    ? base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    : base64;
 }

--- a/src/tools/hash-text/hash-text.vue
+++ b/src/tools/hash-text/hash-text.vue
@@ -1,39 +1,35 @@
 <script setup lang="ts">
-import type { lib } from 'crypto-js';
-import { enc, MD5, RIPEMD160, SHA1, SHA3, SHA224, SHA256, SHA384, SHA512 } from 'crypto-js';
+import type { Encoding } from './hash-text.service';
+import { md5, ripemd160, sha1 } from '@noble/hashes/legacy.js';
+import { sha224, sha256, sha384, sha512 } from '@noble/hashes/sha2.js';
+import { keccak_512 } from '@noble/hashes/sha3.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { useQueryParam } from '@/composable/queryParams';
 import InputCopyable from '../../components/InputCopyable.vue';
-import { convertHexToBin } from './hash-text.service';
+import { formatBytes } from './hash-text.service';
 
 const { t } = useI18n();
 
 const algos = {
-  MD5,
-  SHA1,
-  SHA256,
-  SHA224,
-  SHA512,
-  SHA384,
-  SHA3,
-  RIPEMD160,
+  MD5: md5,
+  SHA1: sha1,
+  SHA256: sha256,
+  SHA224: sha224,
+  SHA512: sha512,
+  SHA384: sha384,
+  // crypto-js's "SHA3" was actually Keccak (the pre-NIST padding); keccak_512
+  // reproduces the exact output the tool has always shown for the "SHA3" row.
+  SHA3: keccak_512,
+  RIPEMD160: ripemd160,
 } as const;
 
 type AlgoNames = keyof typeof algos;
-type Encoding = keyof typeof enc | 'Bin';
 const algoNames = Object.keys(algos) as AlgoNames[];
 const encoding = useQueryParam<Encoding>({ defaultValue: 'Hex', name: 'encoding' });
 const clearText = ref('');
 
-function formatWithEncoding(words: lib.WordArray, encoding: Encoding) {
-  if (encoding === 'Bin') {
-    return convertHexToBin(words.toString(enc.Hex));
-  }
-
-  return words.toString(enc[encoding]);
-}
-
-const hashText = (algo: AlgoNames, value: string) => formatWithEncoding(algos[algo](value), encoding.value);
+const hashText = (algo: AlgoNames, value: string) => formatBytes(algos[algo](utf8ToBytes(value)), encoding.value);
 </script>
 
 <template>

--- a/src/tools/hmac-generator/hmac-generator.service.ts
+++ b/src/tools/hmac-generator/hmac-generator.service.ts
@@ -1,40 +1,28 @@
-import type { lib } from 'crypto-js';
-import {
-  enc,
-  HmacMD5,
-  HmacRIPEMD160,
-  HmacSHA1,
-  HmacSHA3,
-  HmacSHA224,
-  HmacSHA256,
-  HmacSHA384,
-  HmacSHA512,
-} from 'crypto-js';
-import { convertHexToBin } from '../hash-text/hash-text.service';
+import type { Encoding } from '../hash-text/hash-text.service';
+import { hmac } from '@noble/hashes/hmac.js';
+import { md5, ripemd160, sha1 } from '@noble/hashes/legacy.js';
+import { sha224, sha256, sha384, sha512 } from '@noble/hashes/sha2.js';
+import { keccak_512 } from '@noble/hashes/sha3.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
+import { formatBytes } from '../hash-text/hash-text.service';
 
-export { algos, computeHmac, formatWithEncoding };
+export { algos, computeHmac };
+export type { Encoding };
 
 export type AlgoName = keyof typeof algos;
 
-export type Encoding = keyof typeof enc | 'Bin';
-
 const algos = {
-  MD5: HmacMD5,
-  RIPEMD160: HmacRIPEMD160,
-  SHA1: HmacSHA1,
-  SHA3: HmacSHA3,
-  SHA224: HmacSHA224,
-  SHA256: HmacSHA256,
-  SHA384: HmacSHA384,
-  SHA512: HmacSHA512,
+  MD5: md5,
+  RIPEMD160: ripemd160,
+  SHA1: sha1,
+  // crypto-js's "SHA3" was actually Keccak; keccak_512 keeps HMAC-SHA3 output
+  // identical to what the tool produced before.
+  SHA3: keccak_512,
+  SHA224: sha224,
+  SHA256: sha256,
+  SHA384: sha384,
+  SHA512: sha512,
 } as const;
-
-function formatWithEncoding(words: lib.WordArray, encoding: Encoding): string {
-  if (encoding === 'Bin') {
-    return convertHexToBin(words.toString(enc.Hex));
-  }
-  return words.toString(enc[encoding]);
-}
 
 function computeHmac({
   plainText,
@@ -47,5 +35,7 @@ function computeHmac({
   hashFunction: AlgoName;
   encoding: Encoding;
 }): string {
-  return formatWithEncoding(algos[hashFunction](plainText, secret), encoding);
+  // HMAC(key = secret, message = plainText); crypto-js's Hmac* took (message, secret).
+  const mac = hmac(algos[hashFunction], utf8ToBytes(secret), utf8ToBytes(plainText));
+  return formatBytes(mac, encoding);
 }

--- a/src/tools/ipv6-ula-generator/ipv6-ula-generator.service.ts
+++ b/src/tools/ipv6-ula-generator/ipv6-ula-generator.service.ts
@@ -1,12 +1,12 @@
-import { SHA1 } from 'crypto-js';
+import { sha1 } from '@noble/hashes/legacy.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 export { generateUla };
 
 function generateUla({ macAddress, timestamp = Date.now() }: { macAddress: string; timestamp?: number }) {
   // RFC 4193 section 3.2.2 mandates SHA-1 for deriving the ULA Global ID;
   // this is pseudo-random ID generation, not a security control.
-  const hex40bit = SHA1(timestamp + macAddress)
-    .toString()
+  const hex40bit = bytesToHex(sha1(utf8ToBytes(`${timestamp}${macAddress}`)))
     .substring(30);
 
   const ula = `fd${hex40bit.substring(0, 2)}:${hex40bit.substring(2, 6)}:${hex40bit.substring(6)}`;

--- a/src/tools/otp-code-generator-and-validator/otp-code-generator-and-validator.service.ts
+++ b/src/tools/otp-code-generator-and-validator/otp-code-generator-and-validator.service.ts
@@ -1,4 +1,6 @@
-import { enc, HmacSHA1 } from 'crypto-js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha1 } from '@noble/hashes/legacy.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import _ from 'lodash';
 import { createToken } from '../token-generator/token-generator.service';
 
@@ -19,7 +21,8 @@ function hexToBytes(hex: string) {
 }
 
 function computeHMACSha1(message: string, key: string) {
-  return HmacSHA1(enc.Hex.parse(message), enc.Hex.parse(base32toHex(key))).toString(enc.Hex);
+  // message and key are hex strings; HMAC-SHA1 over their decoded bytes.
+  return bytesToHex(hmac(sha1, Uint8Array.from(hexToBytes(base32toHex(key))), Uint8Array.from(hexToBytes(message))));
 }
 
 function base32toHex(base32: string) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -244,10 +244,10 @@ export default defineConfig({
       // get locked in as the new floor. Commit the bumped values.
       thresholds: {
         autoUpdate: true,
-        lines: 97.76,
-        statements: 97.78,
+        lines: 97.77,
+        statements: 97.79,
         functions: 99.01,
-        branches: 96.48,
+        branches: 96.5,
       },
     },
   },


### PR DESCRIPTION
### Description

`crypto-js` is [officially deprecated](https://www.npmjs.com/package/crypto-js) ("Active development discontinued… no longer maintained"). The pinned 4.2.0 isn't itself vulnerable, but it's unmaintained, so this moves the **hashing** tools onto **`@noble/hashes`** — an audited, actively maintained, TypeScript-native, sync, tree-shakeable library that is **already a dependency** of the repo (used by the BIP39 tool). No new dependency is added.

Migrated (4 of the 5 crypto-js consumers):
- **hash-text** — MD5, SHA1, SHA224, SHA256, SHA384, SHA512, SHA3, RIPEMD160
- **hmac-generator** — HMAC over the same set
- **otp generator** — HMAC-SHA1 (TOTP/HOTP)
- **ipv6-ula** — SHA1

**Outputs are byte-identical** — every existing unit-test vector (hex, base64, url-safe base64, binary, TOTP/HOTP codes, ULA blocks) passes **unchanged**. Two details:
- crypto-js's **`SHA3` is actually Keccak** (the pre-NIST padding), so it maps to `@noble/hashes` **`keccak_512`**, not `sha3_512`, to preserve the exact output the "SHA3" row has always shown. Verified: `crypto-js SHA3(x) === noble keccak_512(x)` and `crypto-js HmacSHA3 === noble hmac(keccak_512, …)`.
- a shared `formatBytes()` in `hash-text.service` renders a raw digest as hex / base64 / base64url / binary, matching crypto-js's encoders (lowercase hex, padded base64, url-safe base64 without padding).

**What still uses crypto-js:** the **encryption** tool only. Its legacy ciphers (**TripleDES, RC4, Rabbit**) have no maintained modern replacement (`@noble/ciphers` intentionally omits them), so removing them would drop tool features. crypto-js is now **isolated to that one file** rather than removed entirely — a follow-up can decide whether to drop those legacy ciphers (AES → `@noble/ciphers`) for full removal.

### 🧪 How to test

**Automated:** `pnpm test` — the hash-text, hmac-generator, otp, and ipv6-ula unit suites (34 tests) all pass with their pre-existing vectors, proving identical output. `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm coverage` all green (coverage ratcheted up slightly).

**Manual (on the deploy preview):**
1. **Hash text** (`/hash-text`) — type text; confirm each algorithm's digest matches production, and that switching encoding (Hex / Base64 / Base64url / Binary) still works.
2. **HMAC** (`/hmac-generator`) — enter text + key; confirm each algorithm and encoding matches production.
3. **OTP** (`/otp-code-generator-and-validator`) — confirm the TOTP code matches another authenticator for the same secret.
4. **IPv6 ULA** (`/ipv6-ula-generator`) — confirm a generated ULA for a given MAC is unchanged.
5. **Encryption** (`/encryption`) — unchanged (still crypto-js); confirm AES/TripleDES/RC4/Rabbit round-trip.

### Additional context

- `@noble/hashes` is imported with the `.js` subpath convention already used by `bip39.ts` (`@noble/hashes/sha2.js`, etc.).

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other (dependency maintenance / refactor)

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_