### PR TITLE
refactor(icons): migrate from frozen @vicons/tabler to @tabler/icons-vue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ And automatically adds the import to `src/tools/index.ts`.
 **`index.ts`** - Tool metadata and registration:
 
 ```typescript
-import { ArrowsShuffle } from '@vicons/tabler';
+import { IconArrowsShuffle } from '@tabler/icons-vue';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
@@ -221,7 +221,7 @@ export const tool = defineTool({
   description: 'Tool description',      // SEO description
   keywords: ['keyword1', 'keyword2'],   // Search keywords
   component: () => import('./tool.vue'), // Lazy-loaded component
-  icon: ArrowsShuffle,                  // Icon component
+  icon: IconArrowsShuffle,              // Icon component
   createdAt: new Date('2024-01-15'),   // Creation date (for "new" badge)
   redirectFrom: ['/old-path'],          // Optional: redirect old URLs
 });

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/figlet": "1.7.0",
     "@types/markdown-it": "14.1.2",
     "@vicons/material": "0.13.0",
-    "@vicons/tabler": "0.13.0",
     "@vueuse/core": "14.4.0",
     "@vueuse/head": "2.0.0",
     "@vueuse/router": "14.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@vicons/material':
         specifier: 0.13.0
         version: 0.13.0
-      '@vicons/tabler':
-        specifier: 0.13.0
-        version: 0.13.0
       '@vueuse/core':
         specifier: 14.4.0
         version: 14.4.0(vue@3.5.40(typescript@6.0.3))
@@ -2479,9 +2476,6 @@ packages:
 
   '@vicons/material@0.13.0':
     resolution: {integrity: sha512-lKVxFNprM+CaBkUH3gt6VjIeiMsKQl2zARQMwTCZruQl2vRHzyeZiKeCflWS99CEfv2JzX/6y697smxlzyxcVw==}
-
-  '@vicons/tabler@0.13.0':
-    resolution: {integrity: sha512-AykuhiqjszkIoAL/7knIFm6RDOBS1ZmQdJfQ+RNLEah0fVsxykUFCfMBSNZh8lOzC85EtdD1k5g/sv5GYk0Ohg==}
 
   '@vitejs/plugin-vue-jsx@5.1.6':
     resolution: {integrity: sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==}
@@ -8548,8 +8542,6 @@ snapshots:
       vite: 8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
 
   '@vicons/material@0.13.0': {}
-
-  '@vicons/tabler@0.13.0': {}
 
   '@vitejs/plugin-vue-jsx@5.1.6(supports-color@7.2.0)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -89,8 +89,8 @@
       "matchUpdateTypes": ["major", "minor", "patch"]
     },
     {
-      "groupName": "Vicons",
-      "matchPackageNames": ["@vicons/material", "@vicons/tabler"],
+      "groupName": "Icons",
+      "matchPackageNames": ["@vicons/material", "@tabler/icons-vue"],
       "matchUpdateTypes": ["major", "minor", "patch"]
     },
     {

--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -47,7 +47,7 @@ createToolFile(
 createToolFile(
   `index.ts`,
   `
-import { ArrowsShuffle } from '@vicons/tabler';
+import { IconArrowsShuffle } from '@tabler/icons-vue';
 import { defineTool } from '../tool';
 
 export const tool = defineTool({
@@ -56,7 +56,7 @@ export const tool = defineTool({
   description: '',
   keywords: ['${toolName.split('-').join('\', \'')}'],
   component: () => import('./${toolName}.vue'),
-  icon: ArrowsShuffle,
+  icon: IconArrowsShuffle,
   createdAt: new Date('${new Date().toISOString().split('T')[0]}'),
 });
 `,

--- a/src/components/TextareaCopyable.vue
+++ b/src/components/TextareaCopyable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Copy } from '@vicons/tabler';
+import { IconCopy as Copy } from '@tabler/icons-vue';
 import { useElementSize } from '@vueuse/core';
 import hljs from 'highlight.js/lib/core';
 import iniHljs from 'highlight.js/lib/languages/ini';

--- a/src/layouts/base.layout.vue
+++ b/src/layouts/base.layout.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { ToolCategory } from '@/tools/tools.types';
 
-import { Heart, Home2, Menu2 } from '@vicons/tabler';
+import { IconHeart as Heart, IconHome2 as Home2, IconMenu2 as Menu2 } from '@tabler/icons-vue';
 import { NIcon, useThemeVars } from 'naive-ui';
 
 import { storeToRefs } from 'pinia';

--- a/src/tools/ascii-text-drawer/index.ts
+++ b/src/tools/ascii-text-drawer/index.ts
@@ -1,4 +1,4 @@
-import { Artboard } from '@vicons/tabler';
+import { IconArtboard as Artboard } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/base64-file-converter/index.ts
+++ b/src/tools/base64-file-converter/index.ts
@@ -1,4 +1,4 @@
-import { FileDigit } from '@vicons/tabler';
+import { IconFileDigit as FileDigit } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/base64-string-converter/index.ts
+++ b/src/tools/base64-string-converter/index.ts
@@ -1,4 +1,4 @@
-import { FileDigit } from '@vicons/tabler';
+import { IconFileDigit as FileDigit } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/bcrypt/index.ts
+++ b/src/tools/bcrypt/index.ts
@@ -1,4 +1,4 @@
-import { LockSquare } from '@vicons/tabler';
+import { IconLockSquare as LockSquare } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/benchmark-builder/benchmark-builder.vue
+++ b/src/tools/benchmark-builder/benchmark-builder.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Plus, Trash } from '@vicons/tabler';
+import { IconPlus as Plus, IconTrash as Trash } from '@tabler/icons-vue';
 import { useStorage } from '@vueuse/core';
 import _ from 'lodash';
 

--- a/src/tools/benchmark-builder/dynamic-values.vue
+++ b/src/tools/benchmark-builder/dynamic-values.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Plus, Trash } from '@vicons/tabler';
+import { IconPlus as Plus, IconTrash as Trash } from '@tabler/icons-vue';
 import { useTemplateRefsList, useVModel } from '@vueuse/core';
 import { NInputNumber } from 'naive-ui';
 import { nextTick } from 'vue';

--- a/src/tools/bip39-generator/bip39-generator.vue
+++ b/src/tools/bip39-generator/bip39-generator.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Copy, Refresh } from '@vicons/tabler';
+import { IconCopy as Copy, IconRefresh as Refresh } from '@tabler/icons-vue';
 
 import { useCopy } from '@/composable/copy';
 import { useValidation } from '@/composable/validation';

--- a/src/tools/bip39-generator/index.ts
+++ b/src/tools/bip39-generator/index.ts
@@ -1,4 +1,4 @@
-import { AlignJustified } from '@vicons/tabler';
+import { IconAlignJustified as AlignJustified } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/camera-recorder/index.ts
+++ b/src/tools/camera-recorder/index.ts
@@ -1,4 +1,4 @@
-import { Camera } from '@vicons/tabler';
+import { IconCamera as Camera } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/case-converter/index.ts
+++ b/src/tools/case-converter/index.ts
@@ -1,4 +1,4 @@
-import { LetterCaseToggle } from '@vicons/tabler';
+import { IconLetterCaseToggle as LetterCaseToggle } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/chmod-calculator/index.ts
+++ b/src/tools/chmod-calculator/index.ts
@@ -1,4 +1,4 @@
-import { FileInvoice } from '@vicons/tabler';
+import { IconFileInvoice as FileInvoice } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/color-contrast-checker/index.ts
+++ b/src/tools/color-contrast-checker/index.ts
@@ -1,4 +1,4 @@
-import { Contrast } from '@vicons/tabler';
+import { IconContrast as Contrast } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/color-converter/index.ts
+++ b/src/tools/color-converter/index.ts
@@ -1,4 +1,4 @@
-import { Palette } from '@vicons/tabler';
+import { IconPalette as Palette } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/crontab-generator/index.ts
+++ b/src/tools/crontab-generator/index.ts
@@ -1,4 +1,4 @@
-import { Alarm } from '@vicons/tabler';
+import { IconAlarm as Alarm } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/csv-to-json/index.ts
+++ b/src/tools/csv-to-json/index.ts
@@ -1,4 +1,4 @@
-import { FileText } from '@vicons/tabler';
+import { IconFileText as FileText } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/data-storage-converter/index.ts
+++ b/src/tools/data-storage-converter/index.ts
@@ -1,4 +1,4 @@
-import { Database } from '@vicons/tabler';
+import { IconDatabase as Database } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/date-time-converter/index.ts
+++ b/src/tools/date-time-converter/index.ts
@@ -1,4 +1,4 @@
-import { Calendar } from '@vicons/tabler';
+import { IconCalendar as Calendar } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/device-information/index.ts
+++ b/src/tools/device-information/index.ts
@@ -1,4 +1,4 @@
-import { DeviceDesktop } from '@vicons/tabler';
+import { IconDeviceDesktop as DeviceDesktop } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/docker-run-to-docker-compose-converter/index.ts
+++ b/src/tools/docker-run-to-docker-compose-converter/index.ts
@@ -1,4 +1,4 @@
-import { BrandDocker } from '@vicons/tabler';
+import { IconBrandDocker as BrandDocker } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/duration-converter/index.ts
+++ b/src/tools/duration-converter/index.ts
@@ -1,4 +1,4 @@
-import { Hourglass } from '@vicons/tabler';
+import { IconHourglass as Hourglass } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/email-normalizer/index.ts
+++ b/src/tools/email-normalizer/index.ts
@@ -1,4 +1,4 @@
-import { Mail } from '@vicons/tabler';
+import { IconMail as Mail } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/emoji-picker/index.ts
+++ b/src/tools/emoji-picker/index.ts
@@ -1,4 +1,4 @@
-import { MoodSmile } from '@vicons/tabler';
+import { IconMoodSmile as MoodSmile } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/encryption/index.ts
+++ b/src/tools/encryption/index.ts
@@ -1,4 +1,4 @@
-import { Lock } from '@vicons/tabler';
+import { IconLock as Lock } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/eta-calculator/index.ts
+++ b/src/tools/eta-calculator/index.ts
@@ -1,4 +1,4 @@
-import { Hourglass } from '@vicons/tabler';
+import { IconHourglass as Hourglass } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/file-hash/index.ts
+++ b/src/tools/file-hash/index.ts
@@ -1,4 +1,4 @@
-import { FileCheck } from '@vicons/tabler';
+import { IconFileCheck as FileCheck } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/git-memo/index.ts
+++ b/src/tools/git-memo/index.ts
@@ -1,4 +1,4 @@
-import { BrandGit } from '@vicons/tabler';
+import { IconBrandGit as BrandGit } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/hash-text/index.ts
+++ b/src/tools/hash-text/index.ts
@@ -1,4 +1,4 @@
-import { EyeOff } from '@vicons/tabler';
+import { IconEyeOff as EyeOff } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/html-entities/index.ts
+++ b/src/tools/html-entities/index.ts
@@ -1,4 +1,4 @@
-import { Code } from '@vicons/tabler';
+import { IconCode as Code } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/html-to-markdown/index.ts
+++ b/src/tools/html-to-markdown/index.ts
@@ -1,4 +1,4 @@
-import { Markdown } from '@vicons/tabler';
+import { IconMarkdown as Markdown } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/html-wysiwyg-editor/editor/menu-bar.vue
+++ b/src/tools/html-wysiwyg-editor/editor/menu-bar.vue
@@ -1,24 +1,7 @@
 <script setup lang="ts">
 import type { Editor } from '@tiptap/vue-3';
 import type { Component } from 'vue';
-import {
-  ArrowBack,
-  ArrowForwardUp,
-  Blockquote,
-  Bold,
-  ClearFormatting,
-  Code,
-  CodePlus,
-  H1,
-  H2,
-  H3,
-  H4,
-  Italic,
-  List,
-  ListNumbers,
-  Strikethrough,
-  TextWrap,
-} from '@vicons/tabler';
+import { IconArrowBack as ArrowBack, IconArrowForwardUp as ArrowForwardUp, IconBlockquote as Blockquote, IconBold as Bold, IconClearFormatting as ClearFormatting, IconCode as Code, IconCodePlus as CodePlus, IconH1 as H1, IconH2 as H2, IconH3 as H3, IconH4 as H4, IconItalic as Italic, IconList as List, IconListNumbers as ListNumbers, IconStrikethrough as Strikethrough, IconTextWrap as TextWrap } from '@tabler/icons-vue';
 import MenuBarItem from './menu-bar-item.vue';
 
 const props = defineProps<{ editor: Editor }>();

--- a/src/tools/html-wysiwyg-editor/index.ts
+++ b/src/tools/html-wysiwyg-editor/index.ts
@@ -1,4 +1,4 @@
-import { Edit } from '@vicons/tabler';
+import { IconEdit as Edit } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/integer-base-converter/index.ts
+++ b/src/tools/integer-base-converter/index.ts
@@ -1,4 +1,4 @@
-import { ArrowsLeftRight } from '@vicons/tabler';
+import { IconArrowsLeftRight as ArrowsLeftRight } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/ipv4-address-converter/index.ts
+++ b/src/tools/ipv4-address-converter/index.ts
@@ -1,4 +1,4 @@
-import { Binary } from '@vicons/tabler';
+import { IconBinary as Binary } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/ipv4-range-expander/ipv4-range-expander.vue
+++ b/src/tools/ipv4-range-expander/ipv4-range-expander.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Ipv4RangeExpanderResult } from './ipv4-range-expander.types';
-import { Exchange } from '@vicons/tabler';
+import { IconExchange as Exchange } from '@tabler/icons-vue';
 import { useValidation } from '@/composable/validation';
 import { isValidIpv4 } from '../ipv4-address-converter/ipv4-address-converter.service';
 import { calculateCidr } from './ipv4-range-expander.service';

--- a/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.vue
+++ b/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Netmask } from 'netmask';
-import { ArrowLeft, ArrowRight } from '@vicons/tabler';
+import { IconArrowLeft as ArrowLeft, IconArrowRight as ArrowRight } from '@tabler/icons-vue';
 import { useStorage } from '@vueuse/core';
 import SpanCopyable from '@/components/SpanCopyable.vue';
 import { isNotThrowing } from '@/utils/boolean';

--- a/src/tools/ipv6-ula-generator/index.ts
+++ b/src/tools/ipv6-ula-generator/index.ts
@@ -1,4 +1,4 @@
-import { BuildingFactory } from '@vicons/tabler';
+import { IconBuildingFactory as BuildingFactory } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-minify/index.ts
+++ b/src/tools/json-minify/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-sort-keys/index.ts
+++ b/src/tools/json-sort-keys/index.ts
@@ -1,4 +1,4 @@
-import { SortAscendingLetters } from '@vicons/tabler';
+import { IconSortAscendingLetters as SortAscendingLetters } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-to-csv/index.ts
+++ b/src/tools/json-to-csv/index.ts
@@ -1,4 +1,4 @@
-import { List } from '@vicons/tabler';
+import { IconList as List } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-to-toml/index.ts
+++ b/src/tools/json-to-toml/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-to-typescript/index.ts
+++ b/src/tools/json-to-typescript/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-to-xml/index.ts
+++ b/src/tools/json-to-xml/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-to-yaml-converter/index.ts
+++ b/src/tools/json-to-yaml-converter/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/json-viewer/index.ts
+++ b/src/tools/json-viewer/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/jwt-generator/index.ts
+++ b/src/tools/jwt-generator/index.ts
@@ -1,4 +1,4 @@
-import { Signature } from '@vicons/tabler';
+import { IconSignature as Signature } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/jwt-parser/index.ts
+++ b/src/tools/jwt-parser/index.ts
@@ -1,4 +1,4 @@
-import { Key } from '@vicons/tabler';
+import { IconKey as Key } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/keycode-info/index.ts
+++ b/src/tools/keycode-info/index.ts
@@ -1,4 +1,4 @@
-import { Keyboard } from '@vicons/tabler';
+import { IconKeyboard as Keyboard } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/list-converter/index.ts
+++ b/src/tools/list-converter/index.ts
@@ -1,4 +1,4 @@
-import { List } from '@vicons/tabler';
+import { IconList as List } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/lorem-ipsum-generator/index.ts
+++ b/src/tools/lorem-ipsum-generator/index.ts
@@ -1,4 +1,4 @@
-import { AlignJustified } from '@vicons/tabler';
+import { IconAlignJustified as AlignJustified } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/mac-address-generator/index.ts
+++ b/src/tools/mac-address-generator/index.ts
@@ -1,4 +1,4 @@
-import { Devices } from '@vicons/tabler';
+import { IconDevices as Devices } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/mac-address-lookup/index.ts
+++ b/src/tools/mac-address-lookup/index.ts
@@ -1,4 +1,4 @@
-import { Devices } from '@vicons/tabler';
+import { IconDevices as Devices } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/markdown-to-html/index.ts
+++ b/src/tools/markdown-to-html/index.ts
@@ -1,4 +1,4 @@
-import { Markdown } from '@vicons/tabler';
+import { IconMarkdown as Markdown } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/markdown-toc-generator/index.ts
+++ b/src/tools/markdown-toc-generator/index.ts
@@ -1,4 +1,4 @@
-import { ListDetails } from '@vicons/tabler';
+import { IconListDetails as ListDetails } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/math-evaluator/index.ts
+++ b/src/tools/math-evaluator/index.ts
@@ -1,4 +1,4 @@
-import { Math } from '@vicons/tabler';
+import { IconMath as Math } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/meta-tag-generator/index.ts
+++ b/src/tools/meta-tag-generator/index.ts
@@ -1,4 +1,4 @@
-import { Tags } from '@vicons/tabler';
+import { IconTags as Tags } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/mime-types/index.ts
+++ b/src/tools/mime-types/index.ts
@@ -1,4 +1,4 @@
-import { World } from '@vicons/tabler';
+import { IconWorld as World } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/number-to-words/index.ts
+++ b/src/tools/number-to-words/index.ts
@@ -1,4 +1,4 @@
-import { Vocabulary } from '@vicons/tabler';
+import { IconVocabulary as Vocabulary } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/ocr-image-to-text/index.ts
+++ b/src/tools/ocr-image-to-text/index.ts
@@ -1,4 +1,4 @@
-import { Scan } from '@vicons/tabler';
+import { IconScan as Scan } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/otp-code-generator-and-validator/index.ts
+++ b/src/tools/otp-code-generator-and-validator/index.ts
@@ -1,4 +1,4 @@
-import { DeviceMobile } from '@vicons/tabler';
+import { IconDeviceMobile as DeviceMobile } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/percentage-calculator/index.ts
+++ b/src/tools/percentage-calculator/index.ts
@@ -1,4 +1,4 @@
-import { Percentage } from '@vicons/tabler';
+import { IconPercentage as Percentage } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/phone-parser-and-formatter/index.ts
+++ b/src/tools/phone-parser-and-formatter/index.ts
@@ -1,4 +1,4 @@
-import { Phone } from '@vicons/tabler';
+import { IconPhone as Phone } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/qr-code-generator/index.ts
+++ b/src/tools/qr-code-generator/index.ts
@@ -1,4 +1,4 @@
-import { Qrcode } from '@vicons/tabler';
+import { IconQrcode as Qrcode } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/random-port-generator/index.ts
+++ b/src/tools/random-port-generator/index.ts
@@ -1,4 +1,4 @@
-import { Server } from '@vicons/tabler';
+import { IconServer as Server } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/regex-memo/index.ts
+++ b/src/tools/regex-memo/index.ts
@@ -1,4 +1,4 @@
-import { BrandJavascript } from '@vicons/tabler';
+import { IconBrandJavascript as BrandJavascript } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/regex-tester/index.ts
+++ b/src/tools/regex-tester/index.ts
@@ -1,4 +1,4 @@
-import { Language } from '@vicons/tabler';
+import { IconLanguage as Language } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/roman-numeral-converter/index.ts
+++ b/src/tools/roman-numeral-converter/index.ts
@@ -1,4 +1,4 @@
-import { LetterX } from '@vicons/tabler';
+import { IconLetterX as LetterX } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/rsa-key-pair-generator/index.ts
+++ b/src/tools/rsa-key-pair-generator/index.ts
@@ -1,4 +1,4 @@
-import { Certificate } from '@vicons/tabler';
+import { IconCertificate as Certificate } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/safelink-decoder/index.ts
+++ b/src/tools/safelink-decoder/index.ts
@@ -1,4 +1,4 @@
-import { Mailbox } from '@vicons/tabler';
+import { IconMailbox as Mailbox } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/sql-prettify/index.ts
+++ b/src/tools/sql-prettify/index.ts
@@ -1,4 +1,4 @@
-import { Database } from '@vicons/tabler';
+import { IconDatabase as Database } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/string-escape/index.ts
+++ b/src/tools/string-escape/index.ts
@@ -1,4 +1,4 @@
-import { Quote } from '@vicons/tabler';
+import { IconQuote as Quote } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/string-obfuscator/index.ts
+++ b/src/tools/string-obfuscator/index.ts
@@ -1,4 +1,4 @@
-import { EyeOff } from '@vicons/tabler';
+import { IconEyeOff as EyeOff } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/temperature-converter/index.ts
+++ b/src/tools/temperature-converter/index.ts
@@ -1,4 +1,4 @@
-import { Temperature } from '@vicons/tabler';
+import { IconTemperature as Temperature } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-diff/index.ts
+++ b/src/tools/text-diff/index.ts
@@ -1,4 +1,4 @@
-import { FileDiff } from '@vicons/tabler';
+import { IconFileDiff as FileDiff } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-line-tools/index.ts
+++ b/src/tools/text-line-tools/index.ts
@@ -1,4 +1,4 @@
-import { ListNumbers } from '@vicons/tabler';
+import { IconListNumbers as ListNumbers } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-statistics/index.ts
+++ b/src/tools/text-statistics/index.ts
@@ -1,4 +1,4 @@
-import { FileText } from '@vicons/tabler';
+import { IconFileText as FileText } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-to-binary/index.ts
+++ b/src/tools/text-to-binary/index.ts
@@ -1,4 +1,4 @@
-import { Binary } from '@vicons/tabler';
+import { IconBinary as Binary } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-to-nato-alphabet/index.ts
+++ b/src/tools/text-to-nato-alphabet/index.ts
@@ -1,4 +1,4 @@
-import { Speakerphone } from '@vicons/tabler';
+import { IconSpeakerphone as Speakerphone } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/text-to-unicode/index.ts
+++ b/src/tools/text-to-unicode/index.ts
@@ -1,4 +1,4 @@
-import { TextWrap } from '@vicons/tabler';
+import { IconTextWrap as TextWrap } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/token-generator/index.ts
+++ b/src/tools/token-generator/index.ts
@@ -1,4 +1,4 @@
-import { ArrowsShuffle } from '@vicons/tabler';
+import { IconArrowsShuffle as ArrowsShuffle } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/ulid-generator/index.ts
+++ b/src/tools/ulid-generator/index.ts
@@ -1,4 +1,4 @@
-import { SortDescendingNumbers } from '@vicons/tabler';
+import { IconSortDescendingNumbers as SortDescendingNumbers } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/unicode-inspector/index.ts
+++ b/src/tools/unicode-inspector/index.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@vicons/tabler';
+import { IconTypography as Typography } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/url-encoder/index.ts
+++ b/src/tools/url-encoder/index.ts
@@ -1,4 +1,4 @@
-import { Link } from '@vicons/tabler';
+import { IconLink as Link } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/url-parser/index.ts
+++ b/src/tools/url-parser/index.ts
@@ -1,4 +1,4 @@
-import { Unlink } from '@vicons/tabler';
+import { IconUnlink as Unlink } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/user-agent-parser/index.ts
+++ b/src/tools/user-agent-parser/index.ts
@@ -1,4 +1,4 @@
-import { Browser } from '@vicons/tabler';
+import { IconBrowser as Browser } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/user-agent-parser/user-agent-parser.vue
+++ b/src/tools/user-agent-parser/user-agent-parser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { UserAgentResultSection } from './user-agent-parser.types';
-import { Adjustments, Browser, Cpu, Devices, Engine } from '@vicons/tabler';
+import { IconAdjustments as Adjustments, IconBrowser as Browser, IconCpu as Cpu, IconDevices as Devices, IconEngine as Engine } from '@tabler/icons-vue';
 import { withDefaultOnError } from '@/utils/defaults';
 import { getUserAgentInfo } from './user-agent-parser.service';
 import UserAgentResultCards from './user-agent-result-cards.vue';

--- a/src/tools/uuid-generator/index.ts
+++ b/src/tools/uuid-generator/index.ts
@@ -1,4 +1,4 @@
-import { Fingerprint } from '@vicons/tabler';
+import { IconFingerprint as Fingerprint } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/wifi-qr-code-generator/index.ts
+++ b/src/tools/wifi-qr-code-generator/index.ts
@@ -1,4 +1,4 @@
-import { Qrcode } from '@vicons/tabler';
+import { IconQrcode as Qrcode } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/x509-certificate-parser/index.ts
+++ b/src/tools/x509-certificate-parser/index.ts
@@ -1,4 +1,4 @@
-import { Certificate } from '@vicons/tabler';
+import { IconCertificate as Certificate } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/xml-formatter/index.ts
+++ b/src/tools/xml-formatter/index.ts
@@ -1,4 +1,4 @@
-import { Code } from '@vicons/tabler';
+import { IconCode as Code } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/xml-to-json/index.ts
+++ b/src/tools/xml-to-json/index.ts
@@ -1,4 +1,4 @@
-import { Braces } from '@vicons/tabler';
+import { IconBraces as Braces } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/yaml-to-json-converter/index.ts
+++ b/src/tools/yaml-to-json-converter/index.ts
@@ -1,4 +1,4 @@
-import { AlignJustified } from '@vicons/tabler';
+import { IconAlignJustified as AlignJustified } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/yaml-to-toml/index.ts
+++ b/src/tools/yaml-to-toml/index.ts
@@ -1,4 +1,4 @@
-import { AlignJustified } from '@vicons/tabler';
+import { IconAlignJustified as AlignJustified } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 

--- a/src/tools/yaml-viewer/index.ts
+++ b/src/tools/yaml-viewer/index.ts
@@ -1,4 +1,4 @@
-import { AlignJustified } from '@vicons/tabler';
+import { IconAlignJustified as AlignJustified } from '@tabler/icons-vue';
 import { translate } from '@/plugins/i18n.plugin';
 import { defineTool } from '../tool';
 


### PR DESCRIPTION
### Description

Migrates the app's Tabler icons from **`@vicons/tabler`** (frozen at 0.13.0 — its latest published version) to **`@tabler/icons-vue`** 3.46.0, the actively-maintained official package (already a dependency). This drops `@vicons/tabler` entirely.

**Why:** `@vicons/tabler` hasn't been updated in years and lacks newer glyphs (e.g. the modern X brand logo). Standardising on the maintained package gives access to the current, complete icon set and removes a stale dependency.

**Scope:** All **89 distinct icons** used across the app exist in `@tabler/icons-vue`, so it's a clean 1:1 mapping across **95 files**.

**Approach (deliberately low-risk):** only the import statements are rewritten, aliasing back to the original local names:

```diff
-import { Heart, Home2, Menu2 } from '@vicons/tabler';
+import { IconHeart as Heart, IconHome2 as Home2, IconMenu2 as Menu2 } from '@tabler/icons-vue';
```

Every one of the 116 usage sites (`icon: Heart`, `:component="Heart"`, `<Heart />`) is left untouched. This avoids blindly renaming identifiers that collide with common words (`Code`, `Binary`, `Calendar`, `Browser`, …). `pnpm typecheck` and `pnpm build` both pass, confirming every icon resolves.

**Also updated to the new convention (new tools use clean `IconX` names, no alias):**
- `scripts/create-tool.mjs` — the tool scaffolder
- `renovate.json` — the icon dependency group (`@vicons/tabler` → `@tabler/icons-vue`)
- `CLAUDE.md` — the tool-definition example

`@vicons/material` (a separate Material icon set, 10 files) is intentionally kept — `@tabler/icons-vue` has no drop-in for those.

### Additional context

**Visual regression:** Tabler redrew some glyphs between 0.13 and 3.x, so tools that render a Tabler icon *in their content area* will produce shifted snapshots and need refreshed goldens. Nav/home icons aren't in the per-tool snapshots, so most goldens shouldn't move. I'll refresh whatever the visual-regression suite flags as part of driving this to green.

Validated locally: `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other (dependency migration / refactor)

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.
- [X] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — mechanical import swap; validated by typecheck/build and the visual-regression suite.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_