### PR TITLE
refactor(markdown): consolidate on markdown-it, drop marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "libphonenumber-js": "1.13.10",
     "lodash": "4.18.1",
     "markdown-it": "15.0.0",
-    "marked": "18.0.9",
     "mathjs": "15.2.0",
     "mime-types": "3.0.2",
     "monaco-editor": "0.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,6 @@ importers:
       markdown-it:
         specifier: 15.0.0
         version: 15.0.0
-      marked:
-        specifier: 18.0.9
-        version: 18.0.9
       mathjs:
         specifier: 15.2.0
         version: 15.2.0
@@ -4555,11 +4552,6 @@ packages:
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
-    hasBin: true
-
-  marked@18.0.9:
-    resolution: {integrity: sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==}
-    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -10923,8 +10915,6 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
-
-  marked@18.0.9: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/ui/c-markdown/c-markdown.vue
+++ b/src/ui/c-markdown/c-markdown.vue
@@ -1,20 +1,25 @@
 <script setup lang="ts">
 // @ts-nocheck
 import DomPurify from 'dompurify';
-import { marked } from 'marked';
+import MarkdownIt from 'markdown-it';
 
 const props = withDefaults(defineProps<{ markdown?: string }>(), { markdown: '' });
 const { markdown } = toRefs(props);
 
-marked.use({
-  renderer: {
-    link(href, title, text) {
-      return `<a class="text-primary transition decoration-none hover:underline" href="${href}" target="_blank" rel="noopener">${text}</a>`;
-    },
-  },
-});
+const md = new MarkdownIt();
 
-const html = computed(() => DomPurify.sanitize(marked(markdown.value), { ADD_ATTR: ['target'] }));
+// Render links with the app's styling and open them safely in a new tab.
+const renderToken = (tokens, idx, options, env, self) => self.renderToken(tokens, idx, options);
+const defaultLinkOpen = md.renderer.rules.link_open ?? renderToken;
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  const token = tokens[idx];
+  token.attrSet('class', 'text-primary transition decoration-none hover:underline');
+  token.attrSet('target', '_blank');
+  token.attrSet('rel', 'noopener');
+  return defaultLinkOpen(tokens, idx, options, env, self);
+};
+
+const html = computed(() => DomPurify.sanitize(md.render(markdown.value), { ADD_ATTR: ['target'] }));
 </script>
 
 <template>


### PR DESCRIPTION
### Description

The app carried **two markdown parsers** — `marked` and `markdown-it` — for no principled reason (organic growth). This unifies on one and removes `marked`.

**Usage before:**
- `marked` → only the shared `c-markdown` component, which is consumed in exactly **one place**: the About page (trusted i18n content).
- `markdown-it` → the **Markdown-to-HTML tool**, which has exact-output unit tests (including an explicit "escapes raw HTML by default" assertion).

**Direction chosen — keep `markdown-it`, migrate `c-markdown`, drop `marked`:**
- `markdown-it` is the more CommonMark-compliant, **safer-by-default** parser (raw HTML in source is escaped; `c-markdown` still runs DOMPurify on top).
- Blast radius is minimal — only the About page renders through `c-markdown`, and it isn't in any e2e/visual snapshot.
- The Markdown-to-HTML tool and its 10 unit tests are **completely untouched**.

The old `marked` setup added a custom link renderer (app styling + open-in-new-tab). That's reproduced exactly with a `markdown-it` `link_open` rule — verified output:

```html
<a href="https://it-tools.tech" class="text-primary transition decoration-none hover:underline" target="_blank" rel="noopener">IT Tools</a>
```

### Additional context

Validated locally: `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass; the markdown-to-html tool's unit tests still pass (10/10). Link/heading/HTML-escaping output was verified directly against `markdown-it`. No visual goldens are affected.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other (dependency consolidation / refactor)

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving.
- [X] Ideally, include relevant tests that fail without this PR but pass with it. _(N/A — behavior-preserving swap in a shared component; the existing markdown-to-html tests continue to pass unchanged.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6YUQS1vxUBcxJdh6NNWCn)_