### PR TITLE
fix(renovate): resolve trivy-action from GitHub Releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,11 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Resolve aquasecurity/trivy-action versions from GitHub Releases instead of tags. Renovate's default github-tags lookup for this action intermittently returns no-result (its tags were unavailable to the API during the action's supply-chain incident remediation). The action cuts a GitHub Release for every version, so github-releases is a more reliable source; digest pinning is unaffected.",
+      "matchPackageNames": ["aquasecurity/trivy-action"],
+      "overrideDatasource": "github-releases"
+    },
+    {
       "description": "Automerge low-risk devDependency updates once CI passes",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
### Description

Renovate reported a lookup failure for the `aquasecurity/trivy-action` GitHub Action used by the Trivy image-scan steps in `.github/workflows/ci.yml`:

> Failed to look up github-tags package aquasecurity/trivy-action: no-result.

**Root cause.** `aquasecurity/trivy-action` was affected by supply-chain compromises (imposter commits / malicious tags), which triggered incident response on the repository. During remediation its git tags were unavailable to the GitHub API, so Renovate's default `github-tags` datasource returned `no-result` and could not verify/update the digest-pinned reference. The repository and its version tags are healthy again — `git ls-remote` confirms every version tag resolves and that the pinned SHA `ed142fd…` correctly dereferences `v0.36.0` — so the workflow pin itself is valid and points to a clean release.

**Fix.** The action publishes a GitHub *Release* for every version, so this PR points Renovate at the more resilient `github-releases` datasource for this one package via a `packageRules` override in `renovate.json`. Version discovery no longer depends on the `github-tags` endpoint, while digest pinning is unaffected.

```json
{
  "matchPackageNames": ["aquasecurity/trivy-action"],
  "overrideDatasource": "github-releases"
}
```

This is a config-only change. The workflow's Trivy scan steps and their digest pin (`aquasecurity/trivy-action@ed142fd… # v0.36.0`) are intentionally left untouched.

### Additional context

- No change to `ci.yml` — the security-critical Trivy audit/gate steps are unchanged.
- The override is fully reversible; if `github-tags` recovers upstream it is a harmless no-op.
- `renovate.json` validated as well-formed JSON.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it. <!-- N/A: CI/Renovate config change, not covered by the app test suite. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_0125epc7tmRzKscBP4H6ybUD)_