### PR TITLE
chore(renovate): adopt config:best-practices and enforce supply-chain pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "security:openssf-scorecard"
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "helpers:disableTypesNodeMajor",
     "security:openssf-scorecard",
-    ":enableVulnerabilityAlertsWithLabel(security)"
+    ":enableVulnerabilityAlertsWithLabel(security)",
+    ":automergeStableNonMajor",
+    "group:linters"
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "extends": [
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
-    "security:openssf-scorecard"
+    "helpers:disableTypesNodeMajor",
+    "security:openssf-scorecard",
+    ":enableVulnerabilityAlertsWithLabel(security)"
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
### Description

Modernizes `renovate.json` by adopting Renovate's curated best-practices baseline and layering on presets that match this repo's supply-chain posture and automation appetite. Every existing rule (global `rangeStrategy: pin`, `minimumReleaseAge: 3 days`, lock-file maintenance, and the custom ecosystem grouping) is preserved and merges on top of the presets.

Final `extends`:

```jsonc
"extends": [
  "config:best-practices",                        // was config:recommended
  "helpers:pinGitHubActionDigestsToSemver",       // pin new actions to SHA, keep # vX comment fresh
  "helpers:disableTypesNodeMajor",                // keep @types/node major aligned to the runtime
  "security:openssf-scorecard",                   // OpenSSF Scorecard score in PR bodies
  ":enableVulnerabilityAlertsWithLabel(security)",// label + prioritize vuln-fix PRs
  ":automergeStableNonMajor",                     // automerge stable non-major (runtime too)
  "group:linters"                                 // bundle ESLint/Prettier updates
]
```

**Why each was chosen:**

| Preset | Rationale |
| --- | --- |
| `config:best-practices` | The repo already SHA-pins every Action and Docker base image by hand, but nothing *enforced* it. This bundles `docker:pinDigests` + `helpers:pinGitHubActionDigests` to auto-pin any new/unpinned reference, plus `abandonments:recommended`, `:maintainLockFilesWeekly` and `:configMigration`. |
| `helpers:pinGitHubActionDigestsToSemver` | Keeps the human-readable `# vX.Y.Z` comment bumping on releases while staying digest-pinned — matches the existing `@sha # v7.0.1` style. |
| `helpers:disableTypesNodeMajor` | Keeps `@types/node`'s major aligned with the Node runtime the app targets (built/typed against Node 24), so a stray major can't add type surface ahead of the supported runtime. |
| `security:openssf-scorecard` | Surfaces each dependency's OpenSSF Scorecard score in the update-PR body — fits the cosign / SLSA / SBOM / Trivy focus. |
| `:enableVulnerabilityAlertsWithLabel(security)` | Gives vulnerability-fix PRs a distinct `security` label for triage (the default branch currently has open Dependabot alerts). |
| `:automergeStableNonMajor` | Automerges minor/patch updates to stable (non-0.x) **runtime** deps once CI passes, not just devDependencies. Dependency PRs already run the full pipeline (unit + Chromium e2e + full 3-browser visual regression), so coverage is strong. Majors and 0.x packages still require review. |
| `group:linters` | Bundles ESLint/Prettier tooling into one coherent PR. |

**Deliberately not added** (redundant or superseded): `replacements:all`, `workarounds:all`, merge-confidence badges, `group:monorepos`, `group:recommended` (all inside `config:recommended`); `group:vite` / `group:vueMonorepo` / `group:definitelyTyped` (the existing custom Vue/Vite/Type groups are broader); `:pinAllExceptPeerDependencies` (covered by `rangeStrategy: pin`).

**Deliberately deferred** (policy calls kept off): batching PRs behind a `schedule:` or `group:allNonMajor`, and `:automergeDigest` (auto-merging Action/base-image digests unattended). PR pacing stays continuous to keep security response fast.

Validated with the official `renovate-config-validator` after each change (`Config validated successfully`).

### Additional context

Focused entirely on `renovate.json`; no application code changes. Reviewers may want to confirm they're comfortable with `:automergeStableNonMajor` extending automerge to runtime dependencies (majors still gated by review).

---

### What is the purpose of this pull request?

- [x] Other (CI / dependency-automation configuration)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)