### PR TITLE
fix(deps): remediate transitive vulnerability alerts + add PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,150 @@
+name: PR Labeler
+
+# Automatically tags pull requests based on the files they change:
+#   - area/type labels (ci, docker, dependencies, i18n, ui, tests, ...)
+#   - per-tool labels `tool:<name>` for every src/tools/<name>/ touched
+#   - a single size/* label from the number of lines changed
+#
+# Uses pull_request_target so the token can label PRs opened from forks too.
+# This is safe here because the job never checks out or executes PR code — it
+# only reads the changed-file list through the API and applies labels.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write # needed to auto-create labels that don't exist yet
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from changed files
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const issue_number = pr.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: issue_number, per_page: 100,
+            });
+            const paths = files.map(f => f.filename);
+            const totalChanges = files.reduce((n, f) => n + (f.changes || 0), 0);
+            const has = re => paths.some(p => re.test(p));
+
+            // --- area / type labels ---
+            const desired = new Set();
+            if (has(/^\.github\/workflows\//)) { desired.add('ci'); }
+            if (has(/^(Dockerfile|docker\/|\.dockerignore$)/)) { desired.add('docker'); }
+            if (has(/^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.npmrc)$/)) { desired.add('dependencies'); }
+            if (has(/^renovate\.json$/)) { desired.add('renovate'); desired.add('ci'); }
+            if (has(/(^|\/)locales\//)) { desired.add('i18n'); }
+            if (has(/^src\/(ui|components|layouts)\//)) { desired.add('ui'); }
+            if (has(/^src\/tools\//)) { desired.add('tools'); }
+            if (has(/\.(test|spec|e2e\.spec)\.ts$/) || has(/^(playwright\.config\.ts|vitest\.setup\.ts)$/)) { desired.add('tests'); }
+            if (has(/\.mdx?$/) || has(/^(README|CLAUDE|CHANGELOG|SECURITY|LICENSE)/)) { desired.add('documentation'); }
+            if (has(/^worker\//) || has(/^wrangler\.toml$/)) { desired.add('cloudflare'); }
+            if (has(/^scripts\//)) { desired.add('scripts'); }
+            if (has(/^public\//)) { desired.add('assets'); }
+            if (has(/^(vite\.config\.ts|tsconfig.*\.json|eslint\.config\.mjs|unocss\.config\.ts|\.editorconfig|\.prettierrc|\.versionrc)$/)) { desired.add('build'); }
+
+            // --- per-tool labels ---
+            const MAX_TOOL_LABELS = 12;
+            const toolLabels = new Set();
+            for (const p of paths) {
+              const m = p.match(/^src\/tools\/([^/]+)\//);
+              if (m) { toolLabels.add(`tool:${m[1]}`); }
+            }
+            let toolOverflow = false;
+            if (toolLabels.size > MAX_TOOL_LABELS) {
+              // A sweeping change across many tools — skip the noise, keep `tools`.
+              toolOverflow = true;
+            } else {
+              for (const t of toolLabels) { desired.add(t); }
+            }
+
+            // --- size label (mutually exclusive) ---
+            const size = totalChanges >= 1000 ? 'size/XL'
+              : totalChanges >= 500 ? 'size/L'
+              : totalChanges >= 100 ? 'size/M'
+              : totalChanges >= 30 ? 'size/S'
+              : 'size/XS';
+            desired.add(size);
+
+            // --- colors / descriptions ---
+            const sizeColors = { XS: '0e8a16', S: '5cb85c', M: 'fbca04', L: 'f0ad4e', XL: 'd93f0b' };
+            const areaMeta = {
+              ci: ['fbca04', 'CI / workflow changes'],
+              docker: ['0db7ed', 'Docker image / build'],
+              dependencies: ['0366d6', 'Dependency updates'],
+              renovate: ['027fb5', 'Renovate configuration'],
+              i18n: ['d4c5f9', 'Translations / locales'],
+              ui: ['bfd4f2', 'Shared UI / layout / components'],
+              tools: ['5319e7', 'Tool implementations'],
+              tests: ['0e8a16', 'Unit / e2e tests'],
+              documentation: ['0075ca', 'Documentation'],
+              cloudflare: ['f38020', 'Cloudflare worker / deploy'],
+              scripts: ['fef2c0', 'Build / utility scripts'],
+              assets: ['e99695', 'Static assets'],
+              build: ['c2e0c6', 'Build / tooling config'],
+            };
+            const colorFor = (name) => {
+              if (name.startsWith('tool:')) { return ['c5def5', `Touches the ${name.slice(5)} tool`]; }
+              if (name.startsWith('size/')) { return [sizeColors[name.slice(5)] || 'ededed', 'PR size by lines changed']; }
+              return areaMeta[name] || ['ededed', ''];
+            };
+
+            async function ensureLabel(name) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status !== 404) { throw e; }
+                const [color, description] = colorFor(name);
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } catch (err) {
+                  if (err.status !== 422) { throw err; } // 422 = created concurrently
+                }
+              }
+            }
+
+            for (const name of desired) { await ensureLabel(name); }
+
+            // --- reconcile: only touch machine-owned namespaces (tool:* and size/*) ---
+            const current = (pr.labels || []).map(l => l.name);
+            const stale = current.filter(n =>
+              (n.startsWith('tool:') || n.startsWith('size/')) && !desired.has(n));
+            for (const name of stale) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (e) {
+                if (e.status !== 404) { throw e; }
+              }
+            }
+
+            const toAdd = [...desired].filter(n => !current.includes(n));
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+            }
+
+            // --- job summary ---
+            core.summary
+              .addHeading('PR Labeler', 3)
+              .addRaw(`Changed files: ${paths.length} · lines: ${totalChanges} · size: ${size}`)
+              .addBreak();
+            if (toolOverflow) {
+              core.notice(`PR touches ${toolLabels.size} tools (> ${MAX_TOOL_LABELS}); ` +
+                `skipped per-tool labels and applied 'tools' instead.`);
+            }
+            core.summary
+              .addRaw(`Applied: ${[...desired].sort().join(', ') || '(none)'}`)
+              .write();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify@<3.4.13: 3.4.13
+  ip-address@<10.3.1: 10.4.0
+
 importers:
 
   .:
@@ -3237,9 +3241,6 @@ packages:
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
-
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -3996,9 +3997,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@7.1.0:
-    resolution: {integrity: sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==}
-    engines: {node: '>= 10'}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   ip-cidr@3.1.0:
     resolution: {integrity: sha512-HUCn4snshEX1P8cja/IyU3qk8FVDW8T5zZcegDFbu4w7NojmAhk5NcOgj3M8+0fmumo1afJTPDtJlzsxLdOjtg==}
@@ -5475,9 +5476,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  sprintf-js@1.1.2:
-    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
 
   sql-formatter@15.8.2:
     resolution: {integrity: sha512-kTYRg5FIcvsDtYUG2Qn9pYT6xKwiLJN5TTIvc5Mur6hIg4pSfdpHu8Yyu5bqESLHnVM3mXzD446cb2+uEaKZXg==}
@@ -9396,10 +9394,6 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dompurify@3.4.8:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -10335,14 +10329,11 @@ snapshots:
       hasown: 2.0.4
       side-channel: 1.1.1
 
-  ip-address@7.1.0:
-    dependencies:
-      jsbn: 1.1.0
-      sprintf-js: 1.1.2
+  ip-address@10.4.0: {}
 
   ip-cidr@3.1.0:
     dependencies:
-      ip-address: 7.1.0
+      ip-address: 10.4.0
       jsbn: 1.1.0
 
   is-array-buffer@3.0.5:
@@ -11282,7 +11273,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.13
       marked: 14.0.0
 
   moo@0.5.3: {}
@@ -12147,8 +12138,6 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
-
-  sprintf-js@1.1.2: {}
 
   sql-formatter@15.8.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,15 @@
 packages:
   - '.'
 
+# Force patched versions of transitive dependencies flagged by security
+# advisories that their (unmaintained or slow-moving) parents still pull in.
+# Renovate manages these entries; drop one once the parent ships the fix.
+overrides:
+  # monaco-editor bundles an old dompurify; align it with our direct 3.4.13.
+  dompurify@<3.4.13: 3.4.13
+  # composerize-ts -> ip-cidr pulls a vulnerable ip-address (SSRF, GHSA-mwp4-54f8-5fhr).
+  ip-address@<10.3.1: 10.4.0
+
 allowBuilds:
   esbuild: true
   # tesseract.js' only postinstall is opencollective-postinstall (a funding

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "corepack enable && pnpm install --frozen-lockfile",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "corepack enable && pnpm install --frozen-lockfile",
+  "installCommand": "corepack pnpm install --frozen-lockfile",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
### Description

Follow-up to #865 (Renovate presets), covering two things: clearing the open Dependabot alerts on `main`, and adding automatic PR labeling.

#### 1. Security — remediate transitive vulnerability alerts

All 10 open Dependabot alerts were for **transitive** dependencies (nothing imported directly is vulnerable), which Dependabot can't auto-fix on a pnpm project. Fixed via `pnpm.overrides` (in `pnpm-workspace.yaml`, where this repo keeps pnpm settings):

| Override | Fixes | Notes |
| --- | --- | --- |
| `dompurify@<3.4.13 → 3.4.13` | 2 moderate + 2 low | `monaco-editor` bundled `dompurify@3.4.8`; this aligns it with the `3.4.13` we already ship directly. |
| `ip-address@<10.3.1 → 10.4.0` | **1 HIGH** + 1 moderate | `composerize-ts → ip-cidr` pulled `ip-address@7.1.0` (SSRF `GHSA-mwp4-54f8-5fhr`). `ip-cidr`'s usage is compatible with v10 — verified by tests. |

This clears **6 of 10 alerts, including the only HIGH**. Verified locally: `pnpm audit` drops 10 → 4, the full unit suite (**1216 tests**) passes, `pnpm typecheck` passes, and the docker-run→compose converter (the sole `ip-address` consumer) passes.

**Deliberately not fixed** (no safe/available fix — documented for follow-up):
- **unhead** (2 moderate + 1 low): the whole `@unhead` family is on `1.11.20` via the deprecated `@vueuse/head`; the fix is in `unhead@2.x`, a major that restructured the `@unhead/*` packages and needs a real migration (`@vueuse/head` → `@unhead/vue` v2). The vulnerable APIs (`useHeadSafe`/`makeTagSafe`) are **not used anywhere in the app**, so these aren't in the execution path.
- **elliptic** (1 low): the advisory's patched `6.6.2` isn't published on npm yet (latest is `6.6.1`).

#### 2. CI — PR labeler (`.github/workflows/pr-labeler.yml`)

Tags every PR from its changed files so triage/filtering works off labels:
- **area/type**: `ci`, `docker`, `dependencies`, `renovate`, `i18n`, `ui`, `tools`, `tests`, `documentation`, `cloudflare`, `scripts`, `assets`, `build`;
- **per-tool**: `tool:<name>` for each `src/tools/<name>/` a PR touches (capped at 12 — a wider sweep just gets `tools` to avoid label spam);
- **size**: one mutually-exclusive `size/*` label (XS…XL) from lines changed.

Missing labels are created on demand with stable colors/descriptions, and the machine-owned namespaces (`tool:*`, `size/*`) are reconciled on each `synchronize`. It uses `pull_request_target` so PRs from forks get labeled too — safe here because the job only reads the changed-file list via the API and never checks out or executes PR code. Validated with `actionlint`. (Because `pull_request_target` runs the workflow from the base branch, labeling starts once this is merged to `main`.)

### Additional context

Reviewers may want to confirm comfort with the `ip-address` major override (7 → 10 in a transitive tree); it's covered by the converter's unit tests and the full e2e/visual-regression suite that dependency PRs trigger.

---

### What is the purpose of this pull request?

- [x] Bug fix (security remediation)
- [x] Other (CI tooling)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Include tests / validation: unit suite, typecheck, and `pnpm audit` all verified locally; `actionlint` on the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_