### PR TITLE
ci(pr-labeler): tag dependency PRs with the tools that use the updated package

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,12 +2,14 @@ name: PR Labeler
 
 # Automatically tags pull requests based on the files they change:
 #   - area/type labels (ci, docker, dependencies, i18n, ui, tests, ...)
-#   - per-tool labels `tool:<name>` for every src/tools/<name>/ touched
+#   - per-tool labels `tool:<name>` for every src/tools/<name>/ touched, AND
+#     for dependency PRs, every tool that imports the updated package(s)
 #   - a single size/* label from the number of lines changed
 #
 # Uses pull_request_target so the token can label PRs opened from forks too.
-# This is safe here because the job never checks out or executes PR code — it
-# only reads the changed-file list through the API and applies labels.
+# This is safe because the job only reads the changed-file list via the API and
+# checks out the *base* commit (trusted) — never the PR head — to grep the
+# import graph. It never executes PR code.
 
 on:
   pull_request_target:
@@ -26,10 +28,20 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      # Base branch is trusted (a dependency bump doesn't change the import
+      # graph), so grepping it to map packages -> tools is safe under
+      # pull_request_target. Never checks out the PR head.
+      - name: Checkout base for dependency→tool mapping
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
       - name: Apply labels from changed files
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const cp = require('node:child_process');
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             const issue_number = pr.number;
@@ -57,17 +69,63 @@ jobs:
             if (has(/^public\//)) { desired.add('assets'); }
             if (has(/^(vite\.config\.ts|tsconfig.*\.json|eslint\.config\.mjs|unocss\.config\.ts|\.editorconfig|\.prettierrc|\.versionrc)$/)) { desired.add('build'); }
 
-            // --- per-tool labels ---
-            const MAX_TOOL_LABELS = 12;
+            // --- per-tool labels: from changed paths ... ---
             const toolLabels = new Set();
             for (const p of paths) {
               const m = p.match(/^src\/tools\/([^/]+)\//);
               if (m) { toolLabels.add(`tool:${m[1]}`); }
             }
+
+            // --- ... AND from changed dependencies (map package -> importing tools) ---
+            // Package names whose version lines changed in package.json /
+            // pnpm-workspace.yaml overrides. A dependency PR touches no
+            // src/tools/ file, so this is the only way it gets tool: labels.
+            const changedDeps = new Set();
+            const skipKeys = new Set([
+              'name', 'version', 'description', 'author', 'license', 'type',
+              'packageManager', 'overrides', 'packages', 'allowBuilds', 'onlyBuiltDependencies',
+            ]);
+            const pjPatch = files.find(f => f.filename === 'package.json')?.patch || '';
+            for (const line of pjPatch.split('\n')) {
+              const m = /^[+-]\s*"([^"]+)"\s*:\s*"/.exec(line);
+              if (m && !skipKeys.has(m[1])) { changedDeps.add(m[1]); }
+            }
+            const wsPatch = files.find(f => f.filename === 'pnpm-workspace.yaml')?.patch || '';
+            for (const line of wsPatch.split('\n')) {
+              // overrides entries: `  dompurify@<3.4.13: 3.4.13`  or  `  pkg: x`
+              const m = /^[+-]\s+(@?[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9._-]+)?)(?:@[^:\s]+)?\s*:/i.exec(line);
+              if (m && !skipKeys.has(m[1])) { changedDeps.add(m[1]); }
+            }
+
+            const depToTools = {};
+            for (const pkg of changedDeps) {
+              const esc = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              // Match the package specifier in an import/require: quoted name
+              // followed by a subpath slash or the closing quote.
+              const pattern = `['"]${esc}(/|['"])`;
+              let out = '';
+              try {
+                out = cp.execFileSync(
+                  'grep',
+                  ['-rlE', pattern, 'src/tools', '--include=*.ts', '--include=*.vue'],
+                  { encoding: 'utf8' },
+                );
+              } catch { /* grep exit 1 = no match */ }
+              const hits = [];
+              for (const f of out.split('\n')) {
+                const m = /^src\/tools\/([^/]+)\//.exec(f);
+                if (m) { toolLabels.add(`tool:${m[1]}`); hits.push(m[1]); }
+              }
+              if (hits.length) { depToTools[pkg] = [...new Set(hits)]; }
+            }
+
+            if (toolLabels.size) { desired.add('tools'); }
+
+            // --- cap per-tool labels (a core-dep bump can hit dozens of tools) ---
+            const MAX_TOOL_LABELS = 12;
             let toolOverflow = false;
             if (toolLabels.size > MAX_TOOL_LABELS) {
-              // A sweeping change across many tools — skip the noise, keep `tools`.
-              toolOverflow = true;
+              toolOverflow = true; // keep only the `tools` label, skip the noise
             } else {
               for (const t of toolLabels) { desired.add(t); }
             }
@@ -141,9 +199,13 @@ jobs:
               .addHeading('PR Labeler', 3)
               .addRaw(`Changed files: ${paths.length} · lines: ${totalChanges} · size: ${size}`)
               .addBreak();
+            const depLines = Object.entries(depToTools).map(([p, t]) => `\`${p}\` → ${t.map(x => `tool:${x}`).join(', ')}`);
+            if (depLines.length) {
+              core.summary.addRaw('Dependency → tools:').addList(depLines);
+            }
             if (toolOverflow) {
-              core.notice(`PR touches ${toolLabels.size} tools (> ${MAX_TOOL_LABELS}); ` +
-                `skipped per-tool labels and applied 'tools' instead.`);
+              core.notice(`PR maps to ${toolLabels.size} tools (> ${MAX_TOOL_LABELS}); `
+                + `skipped per-tool labels and applied 'tools' instead.`);
             }
             core.summary
               .addRaw(`Applied: ${[...desired].sort().join(', ') || '(none)'}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(vue@3.5.41(typescript@6.0.3))
       '@unhead/vue':
         specifier: 3.3.1
-        version: 3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vicons/material':
         specifier: 0.13.0
         version: 0.13.0
@@ -8365,17 +8365,17 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
-  '@unhead/bundler@3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))':
+  '@unhead/bundler@3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))':
     dependencies:
       magic-string: 1.1.0
       oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.131.0)(rolldown@1.2.3)
-      unhead: 3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
-      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      unhead: 3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
     optionalDependencies:
       lightningcss: 1.33.0
       oxc-parser: 0.131.0
       rolldown: 1.2.3
-      vite: 8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@oxc-project/types'
@@ -8384,15 +8384,15 @@ snapshots:
       - rollup
       - unloader
 
-  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
+  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(lightningcss@1.33.0)(oxc-parser@0.131.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
       hookable: 6.1.1
-      unhead: 3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
-      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      unhead: 3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:
-      vite: 8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@oxc-project/types'
@@ -12581,12 +12581,12 @@ snapshots:
 
   undici@8.10.0: {}
 
-  unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)):
+  unhead@3.3.1(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       hookable: 6.1.1
-      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
+      unplugin: 3.3.0(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0))
     optionalDependencies:
-      vite: 8.2.0(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1(supports-color@7.2.0))(terser@5.49.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'


### PR DESCRIPTION
### Description

Fixes a gap in the PR labeler: a **dependency update** (e.g. a Renovate PR) only changes `package.json` / `pnpm-lock.yaml` — it never touches `src/tools/`, so the path-based `tool:<name>` labelling never fired for it. Those PRs got `dependencies` but no indication of **which tools are actually affected**.

Now the labeler maps updated packages → importing tools:

1. Parse changed package names from the `package.json` patch **and** from `pnpm-workspace.yaml` `overrides` entries.
2. Check out the **base** commit and `grep src/tools` for each package's import specifier.
3. Add a `tool:<name>` label for every tool that imports it (plus the `tools` label), reusing the existing `>12` overflow guard so a core-dep bump that fans out across the catalogue collapses to just `tools`.

**Example:** a Renovate PR bumping `mathjs` now gets `dependencies`, `tools`, `tool:math-evaluator`; bumping `libphonenumber-js` gets `tool:phone-parser-and-formatter`. A bump to something no tool imports directly (e.g. `@unhead/vue`, used only in layouts/pages) correctly stays `dependencies`-only.

**Why grep the base checkout:** `pull_request_target` can't safely execute PR code, but a version bump doesn't change the import graph — so the base commit (trusted) is an accurate and safe source for the package→tool mapping. The job still only reads the changed-file list via the API and greps the base checkout; it never checks out or runs PR head code.

Verified locally against the real `src/tools` (correct mappings for `mathjs`, `libphonenumber-js`, and the `@unhead/vue` no-match case) and with `actionlint`.

### Additional context

Attribution is by **direct import within a tool's own directory**. A dependency used only indirectly (via `src/composable` or `src/utils`) won't be attributed to a tool — a deliberate scope choice to keep labels meaningful. Because `pull_request_target` runs the workflow from the base branch, the new behaviour takes effect once this merges to `main`.

---

### What is the purpose of this pull request?

- [x] Other (CI tooling improvement)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated: dependency→tool mapping tested locally against `src/tools`; `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_