### PR TITLE
ci(pr-labeler): add new-tool, dependency-change and change-type labels

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,11 @@ name: PR Labeler
 #   - per-tool labels `tool:<name>` for every src/tools/<name>/ touched, AND
 #     for dependency PRs, every tool that imports the updated package(s)
 #   - a single size/* label from the number of lines changed
+#   - `new-tool` when a PR adds a new src/tools/<name>/index.ts
+#   - `new-dependency` / `removed-dependency` / `major-update` from the
+#     package.json diff
+#   - a kind label (enhancement/bug/performance/refactor/documentation) from
+#     the Conventional-Commit PR title
 #
 # Uses pull_request_target so the token can label PRs opened from forks too.
 # This is safe because the job only reads the changed-file list via the API and
@@ -69,6 +74,16 @@ jobs:
             if (has(/^public\//)) { desired.add('assets'); }
             if (has(/^(vite\.config\.ts|tsconfig.*\.json|eslint\.config\.mjs|unocss\.config\.ts|\.editorconfig|\.prettierrc|\.versionrc)$/)) { desired.add('build'); }
 
+            // --- new tool: a brand-new src/tools/<name>/index.ts is ADDED ---
+            if (files.some(f => f.status === 'added' && /^src\/tools\/[^/]+\/index\.ts$/.test(f.filename))) {
+              desired.add('new-tool');
+            }
+
+            // --- kind of change, from the enforced Conventional-Commit PR title ---
+            const titleType = (/^([a-z]+)(?:\([^)]*\))?!?:/i.exec(pr.title || '')?.[1] || '').toLowerCase();
+            const typeToLabel = { feat: 'enhancement', fix: 'bug', perf: 'performance', refactor: 'refactor', docs: 'documentation' };
+            if (typeToLabel[titleType]) { desired.add(typeToLabel[titleType]); }
+
             // --- per-tool labels: from changed paths ... ---
             const toolLabels = new Set();
             for (const p of paths) {
@@ -77,19 +92,33 @@ jobs:
             }
 
             // --- ... AND from changed dependencies (map package -> importing tools) ---
-            // Package names whose version lines changed in package.json /
-            // pnpm-workspace.yaml overrides. A dependency PR touches no
-            // src/tools/ file, so this is the only way it gets tool: labels.
-            const changedDeps = new Set();
+            // Parse the package.json patch into old/new versions per package so
+            // we can both map packages -> tools and classify the change (added /
+            // removed / major bump). A dependency PR touches no src/tools/ file,
+            // so this is the only way it gets tool: labels.
             const skipKeys = new Set([
               'name', 'version', 'description', 'author', 'license', 'type',
               'packageManager', 'overrides', 'packages', 'allowBuilds', 'onlyBuiltDependencies',
             ]);
+            const oldVer = {}, newVer = {};
             const pjPatch = files.find(f => f.filename === 'package.json')?.patch || '';
             for (const line of pjPatch.split('\n')) {
-              const m = /^[+-]\s*"([^"]+)"\s*:\s*"/.exec(line);
-              if (m && !skipKeys.has(m[1])) { changedDeps.add(m[1]); }
+              const m = /^([+-])\s*"([^"]+)"\s*:\s*"([^"]+)"/.exec(line);
+              if (!m || skipKeys.has(m[2])) { continue; }
+              if (m[1] === '+') { newVer[m[2]] = m[3]; } else { oldVer[m[2]] = m[3]; }
             }
+            const changedDeps = new Set([...Object.keys(oldVer), ...Object.keys(newVer)]);
+
+            // classify: added / removed dependency, and major-version bumps
+            const majorOf = v => String(v).replace(/^\D*/, '').split('.')[0];
+            for (const name of changedDeps) {
+              const hasOld = name in oldVer, hasNew = name in newVer;
+              if (hasNew && !hasOld) { desired.add('new-dependency'); }
+              else if (hasOld && !hasNew) { desired.add('removed-dependency'); }
+              else if (hasOld && hasNew && majorOf(oldVer[name]) !== majorOf(newVer[name])) { desired.add('major-update'); }
+            }
+
+            // pnpm-workspace.yaml overrides also feed the package -> tool mapping
             const wsPatch = files.find(f => f.filename === 'pnpm-workspace.yaml')?.patch || '';
             for (const line of wsPatch.split('\n')) {
               // overrides entries: `  dompurify@<3.4.13: 3.4.13`  or  `  pkg: x`
@@ -154,6 +183,14 @@ jobs:
               scripts: ['fef2c0', 'Build / utility scripts'],
               assets: ['e99695', 'Static assets'],
               build: ['c2e0c6', 'Build / tooling config'],
+              'new-tool': ['0e8a16', 'Adds a brand-new tool'],
+              'new-dependency': ['d93f0b', 'Adds a new dependency'],
+              'removed-dependency': ['5319e7', 'Removes a dependency'],
+              'major-update': ['b60205', 'Major-version dependency update'],
+              enhancement: ['a2eeef', 'New feature or enhancement'],
+              bug: ['d73a4a', 'Bug fix'],
+              performance: ['fbca04', 'Performance improvement'],
+              refactor: ['d4c5f9', 'Code refactor'],
             };
             const colorFor = (name) => {
               if (name.startsWith('tool:')) { return ['c5def5', `Touches the ${name.slice(5)} tool`]; }


### PR DESCRIPTION
### Description

Makes the PR labeler describe **what kind of change** a PR is, not just where it lands. Four additions on top of the existing area / per-tool / size logic (all reuse the same auto-create-label path):

| Label(s) | Trigger |
| --- | --- |
| `new-tool` | A brand-new `src/tools/<name>/index.ts` is **added** (file status = `added`) — flags PRs that introduce a whole tool (needs registry entry, i18n keys, e2e/visual golden). |
| `new-dependency` / `removed-dependency` | The `package.json` patch has an added line with no matching removed line (new dep), or vice-versa (removal) — distinct from a version bump. Fits the repo's supply-chain focus. |
| `major-update` | A dependency's semver **major** changes (e.g. `15.x → 16.x`). Reuses the label name Renovate already applies, so it also covers non-Renovate PRs. |
| `enhancement` / `bug` / `performance` / `refactor` / `documentation` | Mapped from the enforced Conventional-Commit PR title (`feat`/`fix`/`perf`/`refactor`/`docs`). |

### How it works

The `package.json` patch is parsed into old/new versions per package, which powers both the existing package→tool mapping and the new add/remove/major classification. The title kind comes from the type prefix the repo already enforces via `pr-title.yml`, so `chore`/`ci`/`test`/`style` correctly produce no kind label.

Validated locally:
- classification — `mathjs 15→16` → `major-update`, a new `smol-toml` line → `new-dependency`, a removed `xml-js` line → `removed-dependency`, a `vite` patch bump → no label;
- title → kind — `feat(x):`→`enhancement`, `fix(deps):`→`bug`, `chore(...)`→none;
- `new-tool` — an added `src/tools/*/index.ts` → true;
- `actionlint` passes.

### Additional context

These new labels are **add-only** (unlike the machine-owned `tool:*` / `size/*` namespaces which are reconciled). Title edits don't trigger the workflow, and diff-derived labels are stable across a PR's life, so add-only avoids ever fighting a maintainer who curates a label by hand. Takes effect once merged to `main` (`pull_request_target` runs the base branch's workflow).

---

### What is the purpose of this pull request?

- [x] Other (CI tooling improvement)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated the classification, title parsing and new-tool detection locally; `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_