### PR TITLE
chore(renovate): rebase PRs on main before merge to prevent stale-base merges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
+  "rebaseWhen": "behind-base-branch",
   "labels": ["dependencies"],
   "ignorePaths": [
     "**/node_modules/**",


### PR DESCRIPTION
### Description

Adds `"rebaseWhen": "behind-base-branch"` to `renovate.json` so Renovate keeps every open PR rebased onto `main` whenever the base moves.

**Why:** `:automergeStableNonMajor` (added in #865) lets a dependency PR auto-merge after passing CI — but by default that CI can have run against an **older base**. The merge result on `main` is then never validated as-merged. That's exactly how a badly-resolved `pnpm-lock.yaml` reached `main` and broke every deploy with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` (repaired in #875): two dependency changes whose lockfiles didn't compose.

With `behind-base-branch`, Renovate rebases the PR before it can merge, so CI (frozen install + build) always runs against the **actual merge result** — a lockfile/merge conflict fails the PR instead of `main`. The trade-off is some extra CI churn on busy days, which is worth a reliably-green `main`.

```diff
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
+  "rebaseWhen": "behind-base-branch",
   "labels": ["dependencies"],
```

Validated with the official `renovate-config-validator` (`Config validated successfully`).

### Additional context

This covers Renovate's own PRs. For the same guarantee on **human** merges, enable the repo-settings toggle **"Require branches to be up to date before merging"** in branch protection for `main` — that's an admin setting, not file-controlled, so it's out of scope for this PR but recommended as the complementary step.

---

### What is the purpose of this pull request?

- [x] Other (dependency-automation hardening)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_