### PR TITLE
ci(pr-title): skip draft PRs, validate on ready-for-review

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,7 +7,7 @@ name: pr-title
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
   pull-requests: read
@@ -18,6 +18,11 @@ concurrency:
 
 jobs:
   validate:
+    # Skip drafts — a work-in-progress title (e.g. an agent's "[WIP] …"
+    # placeholder) isn't final yet. The `ready_for_review` trigger re-runs this
+    # the moment a draft is marked ready, so the title is still validated before
+    # it can be merged.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
### Description

The Conventional-Commit PR-title check currently runs on all PRs, including drafts. Draft PRs often carry a non-final title — most visibly the `[WIP] …` placeholder that GitHub's coding-agent PRs open with (e.g. #878) — so the check fails for no useful reason.

This skips the job while the PR is a draft and re-runs it the moment the PR is marked ready:

```diff
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 jobs:
   validate:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
```

**Why both parts are needed:** skipping drafts alone would let a PR opened as a draft slip through — its title would never be validated. Adding `ready_for_review` makes the check run exactly at the draft→ready transition, so the title is still gated before a PR can merge (and a draft can't merge anyway). Net effect: no false failures on WIP drafts, same guarantee at merge time.

Validated with `actionlint`.

### Additional context

If `pr-title` is a required status check, note that a draft simply won't report it until it's marked ready — which is fine, since drafts are unmergeable. The check appears and must pass before merge.

---

### What is the purpose of this pull request?

- [x] Other (CI tweak)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated with `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_