### PR TITLE
ci(coverage): report coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -33,3 +33,8 @@ jobs:
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
           fail-on-error: true
+          # actionlint's static permission-scope list predates GitHub's
+          # `code-quality` scope (used by ci.yml to upload coverage to Code
+          # Quality). Ignore that one false positive until actionlint adds it.
+          # `\s` avoids literal spaces so the action keeps it as one flag arg.
+          flags: '-ignore unknown\spermission\sscope\s.code-quality.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       (github.event_name != 'pull_request' || needs.changes.outputs.app == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
+      code-quality: write # let the coverage upload post to GitHub Code Quality
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -124,6 +127,19 @@ jobs:
             coverage/lcov-report
           retention-days: 7
           if-no-files-found: ignore
+
+      # Feed the Cobertura report to GitHub Code Quality; the
+      # github-code-quality[bot] then posts a coverage summary on the PR.
+      # Skipped for fork PRs, which can't write to Code Quality.
+      - name: Upload coverage to GitHub Code Quality
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@64515b666cfee68a0a9944893e7e2359ef331ab8 # v1.4.2
+        with:
+          file: coverage/cobertura-coverage.xml
+          language: javascript
+          label: unit
 
   # Single production build, shared with the E2E jobs below. Gated like `checks`
   # so non-app PRs skip it (and, via `needs: build`, the E2E jobs too).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -203,7 +203,8 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'lcov', 'json-summary'],
+      // 'cobertura' feeds GitHub's Code Quality coverage (ci.yml uploads it).
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'cobertura'],
       // Unit coverage tracks the logic layer (services, composables, utils).
       // Vue SFCs are exercised by the Playwright e2e suite rather than unit
       // tests, so including them would drown this metric in ~0%-covered UI and


### PR DESCRIPTION
### Description

Enables GitHub's built-in **Code Quality → Code coverage** (the feature the "Generate workflow with AI" wizard kicked off in the stalled draft #878). Done cleanly against the existing `checks` job, which already runs `pnpm coverage`.

Three changes:

1. **`vite.config.ts`** — add the `cobertura` reporter (the only format GitHub Code Quality accepts) alongside the existing ones, so `pnpm coverage` also writes `coverage/cobertura-coverage.xml`.
   ```diff
   -      reporter: ['text', 'html', 'lcov', 'json-summary'],
   +      reporter: ['text', 'html', 'lcov', 'json-summary', 'cobertura'],
   ```
2. **`ci.yml`** (`checks` job) — grant `code-quality: write` and add an upload step after the coverage run:
   ```yaml
   - name: Upload coverage to GitHub Code Quality
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     uses: actions/upload-code-coverage@64515b666cfee68a0a9944893e7e2359ef331ab8 # v1.4.2
     with:
       file: coverage/cobertura-coverage.xml
       language: javascript
       label: unit
   ```
   The `if:` skips fork PRs (no Code Quality write). Then `github-code-quality[bot]` posts a coverage summary + per-file breakdown on each PR.
3. **`actionlint.yml`** — ignore actionlint's false-positive `unknown permission scope "code-quality"` (its static scope list predates GitHub's new scope). `\s` keeps the ignore regex a single flag argument through the action's flag splitter.

### Validation
- `pnpm coverage` writes a valid `cobertura-coverage.xml` (verified — 1850 lines tracked, matches the existing summary).
- `actionlint` passes on both changed workflows with the ignore flag.

### Required one-time repo setting (not file-controlled)
Enable **Settings → Code security → Code quality**. Until then the upload step simply no-ops. Once on, you can **close the stalled #878**.

### Note for reviewers
The `language: javascript` input is the one value I couldn't verify against the action's (non-public) `action.yml`; if the action rejects it in favor of `typescript`, it's a one-line follow-up — everything else is confirmed.

---

### What is the purpose of this pull request?

- [x] Other (CI — code coverage reporting)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated: cobertura output produced locally; actionlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_