### PR TITLE
refactor: inline exports on declarations (fix CodeQL use-before-declaration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,9 +277,10 @@ import { transformInput } from './tool.service';
 **`tool.service.ts`** - Pure business logic:
 
 ```typescript
-export { transformInput };
-
-function transformInput(input: string): string {
+// Export inline on the declaration (not a separate `export { … }` block at the
+// top of the file — that references the declaration before it appears, which
+// CodeQL flags as js/use-before-declaration).
+export function transformInput(input: string): string {
   // Pure function - no Vue dependencies
   // Easy to test
   return input.toUpperCase();

--- a/src/composable/computedRefreshable.ts
+++ b/src/composable/computedRefreshable.ts
@@ -1,9 +1,7 @@
 import { computedAsync, watchThrottled } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
 
-export { computedRefreshable, computedRefreshableAsync };
-
-function computedRefreshable<T>(getter: () => T, { throttle }: { throttle?: number } = {}) {
+export function computedRefreshable<T>(getter: () => T, { throttle }: { throttle?: number } = {}) {
   const dirty = ref(true);
   let value: T;
 
@@ -27,7 +25,7 @@ function computedRefreshable<T>(getter: () => T, { throttle }: { throttle?: numb
   return [computedValue, update] as const;
 }
 
-function computedRefreshableAsync<T>(getter: () => Promise<T>, defaultValue?: T) {
+export function computedRefreshableAsync<T>(getter: () => Promise<T>, defaultValue?: T) {
   const dirty = ref(true);
   let value: T;
 

--- a/src/composable/downloadBase64.ts
+++ b/src/composable/downloadBase64.ts
@@ -2,14 +2,7 @@ import type { Ref } from 'vue';
 import _ from 'lodash';
 import { extension as getExtensionFromMimeType, lookup as getMimeTypeFromExtension } from 'mime-types';
 
-export {
-  getExtensionFromMimeType,
-  getMimeTypeFromBase64,
-  getMimeTypeFromExtension,
-  previewImageFromBase64,
-  useDownloadFileFromBase64,
-  useDownloadFileFromBase64Refs,
-};
+export { getExtensionFromMimeType, getMimeTypeFromExtension };
 
 const commonMimeTypesSignatures = {
   'JVBERi0': 'application/pdf',
@@ -19,7 +12,7 @@ const commonMimeTypesSignatures = {
   '/9j/': 'image/jpg',
 };
 
-function getMimeTypeFromBase64({ base64String }: { base64String: string }) {
+export function getMimeTypeFromBase64({ base64String }: { base64String: string }) {
   const [,mimeTypeFromBase64] = base64String.match(/data:(.*?);base64/i) ?? [];
 
   if (mimeTypeFromBase64) {
@@ -77,7 +70,7 @@ function downloadFromBase64({ sourceValue, filename, extension, fileMimeType }:
   a.click();
 }
 
-function useDownloadFileFromBase64(
+export function useDownloadFileFromBase64(
   { source, filename, extension, fileMimeType }:
   { source: Ref<string>; filename?: string; extension?: string; fileMimeType?: string },
 ) {
@@ -88,7 +81,7 @@ function useDownloadFileFromBase64(
   };
 }
 
-function useDownloadFileFromBase64Refs(
+export function useDownloadFileFromBase64Refs(
   { source, filename, extension }:
   { source: Ref<string>; filename?: Ref<string>; extension?: Ref<string> },
 ) {
@@ -99,7 +92,7 @@ function useDownloadFileFromBase64Refs(
   };
 }
 
-function previewImageFromBase64(base64String: string): HTMLImageElement {
+export function previewImageFromBase64(base64String: string): HTMLImageElement {
   if (base64String === '') {
     throw new Error('Base64 string is empty');
   }

--- a/src/composable/fuzzySearch.ts
+++ b/src/composable/fuzzySearch.ts
@@ -4,9 +4,7 @@ import { get } from '@vueuse/core';
 import Fuse from 'fuse.js';
 import { computed } from 'vue';
 
-export { useFuzzySearch };
-
-function useFuzzySearch<Data>({
+export function useFuzzySearch<Data>({
   search,
   data,
   options = {},

--- a/src/composable/queryParams.ts
+++ b/src/composable/queryParams.ts
@@ -2,8 +2,6 @@ import { useStorage } from '@vueuse/core';
 import { useRouteQuery } from '@vueuse/router';
 import { computed } from 'vue';
 
-export { useQueryParam, useQueryParamOrStorage };
-
 const transformers = {
   number: {
     fromQuery: (value: string) => Number(value),
@@ -25,7 +23,7 @@ const transformers = {
   },
 };
 
-function useQueryParam<T>({ name, defaultValue }: { name: string; defaultValue: T }) {
+export function useQueryParam<T>({ name, defaultValue }: { name: string; defaultValue: T }) {
   const type = typeof defaultValue;
   const transformer = transformers[type as keyof typeof transformers] ?? transformers.string;
 
@@ -41,7 +39,7 @@ function useQueryParam<T>({ name, defaultValue }: { name: string; defaultValue: 
   });
 }
 
-function useQueryParamOrStorage<T>({ name, storageName, defaultValue }: { name: string; storageName: string; defaultValue: T }) {
+export function useQueryParamOrStorage<T>({ name, storageName, defaultValue }: { name: string; storageName: string; defaultValue: T }) {
   const type = typeof defaultValue;
   const transformer = transformers[type as keyof typeof transformers] ?? transformers.string;
 

--- a/src/tools/ascii-text-drawer/ascii-text-drawer.service.ts
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.service.ts
@@ -1,8 +1,6 @@
 import figlet from 'figlet';
 
-export { drawAsciiArtText };
-
-function drawAsciiArtText({ text, font, width }: { text: string; font: string; width: number }): Promise<string> {
+export function drawAsciiArtText({ text, font, width }: { text: string; font: string; width: number }): Promise<string> {
   const options = {
     font,
     width,

--- a/src/tools/base64-file-converter/base64-file-converter.service.ts
+++ b/src/tools/base64-file-converter/base64-file-converter.service.ts
@@ -1,8 +1,6 @@
 import { getExtensionFromMimeType, getMimeTypeFromBase64 } from '@/composable/downloadBase64';
 
-export { getFileExtensionFromBase64 };
-
-function getFileExtensionFromBase64({
+export function getFileExtensionFromBase64({
   base64String,
   defaultExtension = '',
 }: {

--- a/src/tools/base64-string-converter/base64-string-converter.service.ts
+++ b/src/tools/base64-string-converter/base64-string-converter.service.ts
@@ -1,15 +1,13 @@
 import { base64ToText, isValidBase64, textToBase64 } from '@/utils/base64';
 
-export { base64ToString, isBase64StringValid, stringToBase64 };
-
-function stringToBase64(text: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): string {
+export function stringToBase64(text: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): string {
   return textToBase64(text, { makeUrlSafe });
 }
 
-function base64ToString(base64: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): string {
+export function base64ToString(base64: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): string {
   return base64ToText(base64.trim(), { makeUrlSafe });
 }
 
-function isBase64StringValid(base64: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): boolean {
+export function isBase64StringValid(base64: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}): boolean {
   return isValidBase64(base64.trim(), { makeUrlSafe });
 }

--- a/src/tools/basic-auth-generator/basic-auth-generator.service.ts
+++ b/src/tools/basic-auth-generator/basic-auth-generator.service.ts
@@ -1,7 +1,5 @@
 import { textToBase64 } from '@/utils/base64';
 
-export { getBasicAuthHeader };
-
-function getBasicAuthHeader({ username, password }: { username: string; password: string }): string {
+export function getBasicAuthHeader({ username, password }: { username: string; password: string }): string {
   return `Authorization: Basic ${textToBase64(`${username}:${password}`)}`;
 }

--- a/src/tools/bcrypt/bcrypt.service.ts
+++ b/src/tools/bcrypt/bcrypt.service.ts
@@ -1,11 +1,9 @@
 import { compareSync, hashSync } from 'bcryptjs';
 
-export { compareStringWithHash, hashString };
-
-function hashString({ string, saltCount }: { string: string; saltCount: number }): string {
+export function hashString({ string, saltCount }: { string: string; saltCount: number }): string {
   return hashSync(string, saltCount);
 }
 
-function compareStringWithHash({ string, hash }: { string: string; hash: string }): boolean {
+export function compareStringWithHash({ string, hash }: { string: string; hash: string }): boolean {
   return compareSync(string, hash);
 }

--- a/src/tools/bip39-generator/bip39-generator.service.ts
+++ b/src/tools/bip39-generator/bip39-generator.service.ts
@@ -12,18 +12,9 @@ import {
   spanishWordList,
 } from './wordlists';
 
-export {
-  convertEntropyToMnemonic,
-  convertMnemonicToEntropy,
-  generateRandomEntropy,
-  isEntropyHexadecimal,
-  isEntropyLengthValid,
-  languages,
-};
-
 export type Language = keyof typeof languages;
 
-const languages = {
+export const languages = {
   'English': englishWordList,
   'Chinese simplified': chineseSimplifiedWordList,
   'Chinese traditional': chineseTraditionalWordList,
@@ -36,22 +27,22 @@ const languages = {
   'Spanish': spanishWordList,
 };
 
-function generateRandomEntropy(): string {
+export function generateRandomEntropy(): string {
   return generateEntropy();
 }
 
-function convertEntropyToMnemonic({ entropy, language }: { entropy: string; language: Language }): string {
+export function convertEntropyToMnemonic({ entropy, language }: { entropy: string; language: Language }): string {
   return entropyToMnemonic(entropy, languages[language]);
 }
 
-function convertMnemonicToEntropy({ mnemonic, language }: { mnemonic: string; language: Language }): string {
+export function convertMnemonicToEntropy({ mnemonic, language }: { mnemonic: string; language: Language }): string {
   return mnemonicToEntropy(mnemonic, languages[language]);
 }
 
-function isEntropyLengthValid(entropy: string): boolean {
+export function isEntropyLengthValid(entropy: string): boolean {
   return entropy === '' || (entropy.length <= 32 && entropy.length >= 16 && entropy.length % 4 === 0);
 }
 
-function isEntropyHexadecimal(entropy: string): boolean {
+export function isEntropyHexadecimal(entropy: string): boolean {
   return /^[a-f0-9]*$/i.test(entropy);
 }

--- a/src/tools/case-converter/case-converter.service.ts
+++ b/src/tools/case-converter/case-converter.service.ts
@@ -13,81 +13,63 @@ import {
   trainCase,
 } from 'change-case';
 
-export {
-  toCamelCase,
-  toCapitalCase,
-  toConstantCase,
-  toDotCase,
-  toKebabCase,
-  toLowerCase,
-  toMockingCase,
-  toNoCase,
-  toPascalCase,
-  toPascalSnakeCase,
-  toPathCase,
-  toSentenceCase,
-  toSnakeCase,
-  toTrainCase,
-  toUpperCase,
-};
-
-function toLowerCase(input: string): string {
+export function toLowerCase(input: string): string {
   return input.toLocaleLowerCase();
 }
 
-function toUpperCase(input: string): string {
+export function toUpperCase(input: string): string {
   return input.toLocaleUpperCase();
 }
 
-function toCamelCase(input: string): string {
+export function toCamelCase(input: string): string {
   return camelCase(input);
 }
 
-function toCapitalCase(input: string): string {
+export function toCapitalCase(input: string): string {
   return capitalCase(input);
 }
 
-function toConstantCase(input: string): string {
+export function toConstantCase(input: string): string {
   return constantCase(input);
 }
 
-function toDotCase(input: string): string {
+export function toDotCase(input: string): string {
   return dotCase(input);
 }
 
-function toTrainCase(input: string): string {
+export function toTrainCase(input: string): string {
   return trainCase(input);
 }
 
-function toNoCase(input: string): string {
+export function toNoCase(input: string): string {
   return noCase(input);
 }
 
-function toKebabCase(input: string): string {
+export function toKebabCase(input: string): string {
   return kebabCase(input);
 }
 
-function toPascalCase(input: string): string {
+export function toPascalCase(input: string): string {
   return pascalCase(input);
 }
 
-function toPascalSnakeCase(input: string): string {
+export function toPascalSnakeCase(input: string): string {
   return pascalSnakeCase(input);
 }
 
-function toPathCase(input: string): string {
+export function toPathCase(input: string): string {
   return pathCase(input);
 }
 
-function toSentenceCase(input: string): string {
+export function toSentenceCase(input: string): string {
   return sentenceCase(input);
 }
 
-function toSnakeCase(input: string): string {
+export function toSnakeCase(input: string): string {
   return snakeCase(input);
 }
 
-function toMockingCase(input: string): string {
+export function toMockingCase(input: string): string {
   return input
     .split('')
     .map((char, index) => (index % 2 === 0 ? char.toUpperCase() : char.toLowerCase()))

--- a/src/tools/chmod-calculator/chmod-calculator.service.ts
+++ b/src/tools/chmod-calculator/chmod-calculator.service.ts
@@ -1,9 +1,7 @@
 import type { GroupPermissions, Permissions } from './chmod-calculator.types';
 import _ from 'lodash';
 
-export { computeChmodOctalRepresentation, computeChmodSymbolicRepresentation };
-
-function computeChmodOctalRepresentation({ permissions }: { permissions: Permissions }): string {
+export function computeChmodOctalRepresentation({ permissions }: { permissions: Permissions }): string {
   const permissionValue = { read: 4, write: 2, execute: 1 };
 
   const getGroupPermissionValue = (permission: GroupPermissions) =>
@@ -16,7 +14,7 @@ function computeChmodOctalRepresentation({ permissions }: { permissions: Permiss
   ].join('');
 }
 
-function computeChmodSymbolicRepresentation({ permissions }: { permissions: Permissions }): string {
+export function computeChmodSymbolicRepresentation({ permissions }: { permissions: Permissions }): string {
   const permissionValue = { read: 'r', write: 'w', execute: 'x' };
 
   const getGroupPermissionValue = (permission: GroupPermissions) =>

--- a/src/tools/color-contrast-checker/color-contrast-checker.service.ts
+++ b/src/tools/color-contrast-checker/color-contrast-checker.service.ts
@@ -4,28 +4,25 @@ import namesPlugin from 'colord/plugins/names';
 
 extend([a11yPlugin, namesPlugin]);
 
-export { getContrastRatio, getWcagCompliance, isValidColor };
-export type { WcagCompliance };
-
-interface WcagCompliance {
+export interface WcagCompliance {
   normalAa: boolean;
   normalAaa: boolean;
   largeAa: boolean;
   largeAaa: boolean;
 }
 
-function isValidColor(color: string): boolean {
+export function isValidColor(color: string): boolean {
   return colord(color).isValid();
 }
 
 // WCAG contrast ratio between two colors, from 1 (identical) to 21 (black/white).
-function getContrastRatio(foreground: string, background: string): number {
+export function getContrastRatio(foreground: string, background: string): number {
   return colord(foreground).contrast(background);
 }
 
 // WCAG 2.1 thresholds: normal text needs 4.5 (AA) / 7 (AAA); large text
 // (>=18pt or 14pt bold) needs 3 (AA) / 4.5 (AAA).
-function getWcagCompliance(ratio: number): WcagCompliance {
+export function getWcagCompliance(ratio: number): WcagCompliance {
   return {
     normalAa: ratio >= 4.5,
     normalAaa: ratio >= 7,

--- a/src/tools/crontab-generator/crontab-generator.service.ts
+++ b/src/tools/crontab-generator/crontab-generator.service.ts
@@ -1,8 +1,6 @@
 import { isValidCron } from 'cron-validator';
 import cronstrue from 'cronstrue';
 
-export { getCronDescription, isCronValid };
-
 interface CronDescriptionConfig {
   verbose?: boolean;
   dayOfWeekStartIndexZero?: boolean;
@@ -10,11 +8,11 @@ interface CronDescriptionConfig {
   throwExceptionOnParseError?: boolean;
 }
 
-function isCronValid(v: string) {
+export function isCronValid(v: string) {
   return isValidCron(v, { allowBlankDay: true, alias: true, seconds: true });
 }
 
-function getCronDescription(cron: string, config?: CronDescriptionConfig): string {
+export function getCronDescription(cron: string, config?: CronDescriptionConfig): string {
   if (isCronValid(cron)) {
     return cronstrue.toString(cron, config);
   }

--- a/src/tools/css-unit-converter/css-unit-converter.service.ts
+++ b/src/tools/css-unit-converter/css-unit-converter.service.ts
@@ -1,8 +1,6 @@
-export { convertCssUnit, CSS_UNITS, type CssUnit };
+export type CssUnit = 'px' | 'rem' | 'em' | 'pt' | 'pc' | 'in' | 'cm' | 'mm' | '%';
 
-type CssUnit = 'px' | 'rem' | 'em' | 'pt' | 'pc' | 'in' | 'cm' | 'mm' | '%';
-
-const CSS_UNITS: { value: CssUnit; label: string }[] = [
+export const CSS_UNITS: { value: CssUnit; label: string }[] = [
   { value: 'px', label: 'px — pixels' },
   { value: 'rem', label: 'rem — root em' },
   { value: 'em', label: 'em — element em' },
@@ -45,7 +43,7 @@ function fromPx({ px, unit, baseFontSize }: { px: number; unit: CssUnit; baseFon
   return px / ABSOLUTE_PX_PER_UNIT[unit];
 }
 
-function convertCssUnit({
+export function convertCssUnit({
   value,
   from,
   to,

--- a/src/tools/csv-to-json/csv-to-json.service.ts
+++ b/src/tools/csv-to-json/csv-to-json.service.ts
@@ -1,5 +1,3 @@
-export { convertCsvToJson, parseCsv };
-
 interface ParseOptions {
   delimiter?: string;
   // When true, the first row is treated as the header and each record becomes
@@ -9,7 +7,7 @@ interface ParseOptions {
 
 // A small RFC 4180 CSV parser: supports quoted fields, escaped quotes (""),
 // and delimiters/newlines inside quotes. Handles both \n and \r\n line endings.
-function parseCsv(csv: string, { delimiter = ',' }: { delimiter?: string } = {}): string[][] {
+export function parseCsv(csv: string, { delimiter = ',' }: { delimiter?: string } = {}): string[][] {
   const rows: string[][] = [];
   let field = '';
   let row: string[] = [];
@@ -84,7 +82,7 @@ function parseCsv(csv: string, { delimiter = ',' }: { delimiter?: string } = {})
   return rows;
 }
 
-function convertCsvToJson(csv: string, { delimiter = ',', header = true }: ParseOptions = {}): string {
+export function convertCsvToJson(csv: string, { delimiter = ',', header = true }: ParseOptions = {}): string {
   const rows = parseCsv(csv.trim(), { delimiter });
 
   if (rows.length === 0) {

--- a/src/tools/data-storage-converter/data-storage-converter.service.ts
+++ b/src/tools/data-storage-converter/data-storage-converter.service.ts
@@ -1,7 +1,4 @@
-export { convertDataSize, DATA_UNITS };
-export type { DataUnit };
-
-interface DataUnit {
+export interface DataUnit {
   key: string;
   label: string;
   // Number of bytes in one unit.
@@ -10,7 +7,7 @@ interface DataUnit {
 
 // SI (decimal, powers of 1000) and IEC (binary, powers of 1024) units, plus
 // the bit as the smallest unit (1 byte = 8 bits).
-const DATA_UNITS: DataUnit[] = [
+export const DATA_UNITS: DataUnit[] = [
   { key: 'bit', label: 'Bit (b)', bytes: 1 / 8 },
   { key: 'byte', label: 'Byte (B)', bytes: 1 },
   { key: 'kilobyte', label: 'Kilobyte (kB)', bytes: 1e3 },
@@ -27,7 +24,7 @@ const DATA_UNITS: DataUnit[] = [
 
 const UNIT_BY_KEY = new Map(DATA_UNITS.map(unit => [unit.key, unit]));
 
-function convertDataSize({ value, from, to }: { value: number; from: string; to: string }): number {
+export function convertDataSize({ value, from, to }: { value: number; from: string; to: string }): number {
   const fromUnit = UNIT_BY_KEY.get(from);
   const toUnit = UNIT_BY_KEY.get(to);
 

--- a/src/tools/docker-run-to-docker-compose-converter/docker-run-to-docker-compose-converter.service.ts
+++ b/src/tools/docker-run-to-docker-compose-converter/docker-run-to-docker-compose-converter.service.ts
@@ -1,12 +1,10 @@
 import type { ComposerizeResult, Message, MessageType } from 'composerize-ts';
 import { composerize } from 'composerize-ts';
 
-export { convertDockerRunToDockerCompose, getMessagesOfType };
-
-function convertDockerRunToDockerCompose(dockerRun: string): ComposerizeResult {
+export function convertDockerRunToDockerCompose(dockerRun: string): ComposerizeResult {
   return composerize(dockerRun.trim());
 }
 
-function getMessagesOfType({ messages, type }: { messages: Message[]; type: MessageType }): string[] {
+export function getMessagesOfType({ messages, type }: { messages: Message[]; type: MessageType }): string[] {
   return messages.filter(message => message.type === type).map(message => message.value);
 }

--- a/src/tools/duration-converter/duration-converter.service.ts
+++ b/src/tools/duration-converter/duration-converter.service.ts
@@ -1,7 +1,4 @@
-export { convertDuration, DURATION_UNITS, humanizeDuration };
-export type { DurationUnit };
-
-interface DurationUnit {
+export interface DurationUnit {
   key: string;
   label: string;
   // Number of milliseconds in one unit.
@@ -15,7 +12,7 @@ const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 
-const DURATION_UNITS: DurationUnit[] = [
+export const DURATION_UNITS: DurationUnit[] = [
   { key: 'nanosecond', label: 'Nanoseconds (ns)', milliseconds: 1e-6 },
   { key: 'microsecond', label: 'Microseconds (µs)', milliseconds: 1e-3 },
   { key: 'millisecond', label: 'Milliseconds (ms)', milliseconds: MS },
@@ -28,7 +25,7 @@ const DURATION_UNITS: DurationUnit[] = [
 
 const UNIT_BY_KEY = new Map(DURATION_UNITS.map(unit => [unit.key, unit]));
 
-function convertDuration({ value, from, to }: { value: number; from: string; to: string }): number {
+export function convertDuration({ value, from, to }: { value: number; from: string; to: string }): number {
   const fromUnit = UNIT_BY_KEY.get(from);
   const toUnit = UNIT_BY_KEY.get(to);
 
@@ -41,7 +38,7 @@ function convertDuration({ value, from, to }: { value: number; from: string; to:
 
 // Break a duration (given in one unit) down into a human-readable string such
 // as "1 hour, 2 minutes, 3 seconds". Sub-millisecond remainders are dropped.
-function humanizeDuration({ value, from }: { value: number; from: string }): string {
+export function humanizeDuration({ value, from }: { value: number; from: string }): string {
   const fromUnit = UNIT_BY_KEY.get(from);
   if (!fromUnit) {
     throw new Error(`Unknown duration unit: ${from}`);

--- a/src/tools/email-normalizer/email-normalizer.service.ts
+++ b/src/tools/email-normalizer/email-normalizer.service.ts
@@ -1,9 +1,7 @@
 import { normalizeEmail } from 'email-normalizer';
 import { withDefaultOnError } from '@/utils/defaults';
 
-export { normalizeEmails };
-
-function normalizeEmails(rawEmails: string): string {
+export function normalizeEmails(rawEmails: string): string {
   if (!rawEmails) {
     return '';
   }

--- a/src/tools/emoji-picker/emoji-picker.service.ts
+++ b/src/tools/emoji-picker/emoji-picker.service.ts
@@ -1,12 +1,10 @@
-export { escapeUnicode, getEmojiCodePoints };
-
-function escapeUnicode({ emoji }: { emoji: string }) {
+export function escapeUnicode({ emoji }: { emoji: string }) {
   return emoji
     .split('')
     .map(unit => `\\u${unit.charCodeAt(0).toString(16).padStart(4, '0')}`)
     .join('');
 }
 
-function getEmojiCodePoints({ emoji }: { emoji: string }) {
+export function getEmojiCodePoints({ emoji }: { emoji: string }) {
   return emoji.codePointAt(0) ? `0x${emoji.codePointAt(0)?.toString(16)}` : undefined;
 }

--- a/src/tools/encryption/encryption.service.ts
+++ b/src/tools/encryption/encryption.service.ts
@@ -3,16 +3,13 @@ import { chacha20poly1305 } from '@noble/ciphers/chacha.js';
 import { bytesToUtf8, randomBytes, utf8ToBytes } from '@noble/ciphers/utils.js';
 import { scrypt } from '@noble/hashes/scrypt.js';
 
-export { cipherAlgorithms, decryptText, encryptText };
-export type { CipherAlgorithm };
-
 // Modern authenticated ciphers (AEAD): both provide confidentiality *and*
 // tamper detection, so a wrong key or corrupted ciphertext fails loudly on
 // decryption instead of returning garbage. This replaces the legacy crypto-js
 // ciphers (AES-CBC/TripleDES/RC4/Rabbit), which are unauthenticated and, for
 // RC4/3DES, cryptographically broken.
-const cipherAlgorithms = ['AES-GCM', 'ChaCha20-Poly1305'] as const;
-type CipherAlgorithm = typeof cipherAlgorithms[number];
+export const cipherAlgorithms = ['AES-GCM', 'ChaCha20-Poly1305'] as const;
+export type CipherAlgorithm = typeof cipherAlgorithms[number];
 
 const ALGORITHM_ID: Record<CipherAlgorithm, number> = {
   'AES-GCM': 0,
@@ -60,7 +57,7 @@ function base64ToBytes(base64: string): Uint8Array {
   return bytes;
 }
 
-function encryptText({ text, secret, algorithm }: { text: string; secret: string; algorithm: CipherAlgorithm }): string {
+export function encryptText({ text, secret, algorithm }: { text: string; secret: string; algorithm: CipherAlgorithm }): string {
   const salt = randomBytes(SALT_LENGTH);
   const nonce = randomBytes(NONCE_LENGTH);
   const key = deriveKey(secret, salt);
@@ -76,7 +73,7 @@ function encryptText({ text, secret, algorithm }: { text: string; secret: string
   return bytesToBase64(envelope);
 }
 
-function decryptText({ text, secret }: { text: string; secret: string; algorithm?: CipherAlgorithm }): string {
+export function decryptText({ text, secret }: { text: string; secret: string; algorithm?: CipherAlgorithm }): string {
   if (text.trim() === '') {
     return '';
   }

--- a/src/tools/hmac-generator/hmac-generator.service.ts
+++ b/src/tools/hmac-generator/hmac-generator.service.ts
@@ -4,12 +4,11 @@ import { hmac } from '@awasm/noble/hmac.js';
 import { utf8ToBytes } from '@awasm/noble/utils.js';
 import { formatBytes } from '../hash-text/hash-text.service';
 
-export { algos, computeHmac };
 export type { Encoding };
 
 export type AlgoName = keyof typeof algos;
 
-const algos = {
+export const algos = {
   MD5: md5,
   RIPEMD160: ripemd160,
   SHA1: sha1,
@@ -22,7 +21,7 @@ const algos = {
   SHA512: sha512,
 } as const;
 
-function computeHmac({
+export function computeHmac({
   plainText,
   secret,
   hashFunction,

--- a/src/tools/html-entities/html-entities.service.ts
+++ b/src/tools/html-entities/html-entities.service.ts
@@ -1,11 +1,9 @@
 import { escape, unescape } from 'lodash';
 
-export { escapeHtmlEntities, unescapeHtmlEntities };
-
-function escapeHtmlEntities(input: string): string {
+export function escapeHtmlEntities(input: string): string {
   return escape(input);
 }
 
-function unescapeHtmlEntities(input: string): string {
+export function unescapeHtmlEntities(input: string): string {
   return unescape(input);
 }

--- a/src/tools/html-to-markdown/html-to-markdown.service.ts
+++ b/src/tools/html-to-markdown/html-to-markdown.service.ts
@@ -1,8 +1,6 @@
 import TurndownService from 'turndown';
 
-export { convertHtmlToMarkdown };
-
-function convertHtmlToMarkdown(html: string): string {
+export function convertHtmlToMarkdown(html: string): string {
   const turndown = new TurndownService({
     headingStyle: 'atx',
     hr: '---',

--- a/src/tools/http-status-codes/http-status-codes.service.ts
+++ b/src/tools/http-status-codes/http-status-codes.service.ts
@@ -1,12 +1,9 @@
 import Fuse from 'fuse.js';
 import { codesByCategories } from './http-status-codes.constants';
 
-export { allHttpStatusCodes, searchHttpStatusCodes };
-export type { HttpStatusCode };
+export type HttpStatusCode = (typeof codesByCategories)[number]['codes'][number] & { category: string };
 
-type HttpStatusCode = (typeof codesByCategories)[number]['codes'][number] & { category: string };
-
-const allHttpStatusCodes: HttpStatusCode[] = codesByCategories.flatMap(({ codes, category }) =>
+export const allHttpStatusCodes: HttpStatusCode[] = codesByCategories.flatMap(({ codes, category }) =>
   codes.map(code => ({ ...code, category })),
 );
 
@@ -14,6 +11,6 @@ const fuse = new Fuse(allHttpStatusCodes, {
   keys: [{ name: 'code', weight: 3 }, { name: 'name', weight: 2 }, 'description', 'category'],
 });
 
-function searchHttpStatusCodes(query: string): HttpStatusCode[] {
+export function searchHttpStatusCodes(query: string): HttpStatusCode[] {
   return fuse.search(query).map(({ item }) => item);
 }

--- a/src/tools/iban-validator-and-parser/iban-validator-and-parser.service.ts
+++ b/src/tools/iban-validator-and-parser/iban-validator-and-parser.service.ts
@@ -1,7 +1,5 @@
 import { ValidationErrorsIBAN } from 'ibantools';
 
-export { getFriendlyErrors };
-
 const ibanErrorToMessage = {
   [ValidationErrorsIBAN.NoIBANProvided]: 'No IBAN provided',
   [ValidationErrorsIBAN.NoIBANCountry]: 'No IBAN country',
@@ -13,6 +11,6 @@ const ibanErrorToMessage = {
   [ValidationErrorsIBAN.QRIBANNotAllowed]: 'QR-IBAN not allowed',
 };
 
-function getFriendlyErrors(errorCodes: ValidationErrorsIBAN[]) {
+export function getFriendlyErrors(errorCodes: ValidationErrorsIBAN[]) {
   return errorCodes.map(errorCode => ibanErrorToMessage[errorCode]).filter(Boolean);
 }

--- a/src/tools/ipv4-address-converter/ipv4-address-converter.service.ts
+++ b/src/tools/ipv4-address-converter/ipv4-address-converter.service.ts
@@ -1,8 +1,6 @@
 import _ from 'lodash';
 
-export { ipv4ToInt, ipv4ToIpv6, isValidIpv4 };
-
-function ipv4ToInt({ ip }: { ip: string }) {
+export function ipv4ToInt({ ip }: { ip: string }) {
   if (!isValidIpv4({ ip })) {
     return 0;
   }
@@ -13,7 +11,7 @@ function ipv4ToInt({ ip }: { ip: string }) {
     .reduce((acc, part, index) => acc + Number(part) * 256 ** (3 - index), 0);
 }
 
-function ipv4ToIpv6({ ip, prefix = '0000:0000:0000:0000:0000:ffff:' }: { ip: string; prefix?: string }) {
+export function ipv4ToIpv6({ ip, prefix = '0000:0000:0000:0000:0000:ffff:' }: { ip: string; prefix?: string }) {
   if (!isValidIpv4({ ip })) {
     return '';
   }
@@ -31,7 +29,7 @@ function ipv4ToIpv6({ ip, prefix = '0000:0000:0000:0000:0000:ffff:' }: { ip: str
   );
 }
 
-function isValidIpv4({ ip }: { ip: string }) {
+export function isValidIpv4({ ip }: { ip: string }) {
   const cleanIp = ip.trim();
 
   // eslint-disable-next-line regexp/no-empty-alternative -- empty alternative is intentional to match 0-9

--- a/src/tools/ipv4-range-expander/ipv4-range-expander.service.ts
+++ b/src/tools/ipv4-range-expander/ipv4-range-expander.service.ts
@@ -2,8 +2,6 @@ import type { Ipv4RangeExpanderResult } from './ipv4-range-expander.types';
 import { convertBase } from '../integer-base-converter/integer-base-converter.model';
 import { ipv4ToInt } from '../ipv4-address-converter/ipv4-address-converter.service';
 
-export { calculateCidr };
-
 function bits2ip(ipInt: number) {
   return `${ipInt >>> 24}.${(ipInt >> 16) & 255}.${(ipInt >> 8) & 255}.${ipInt & 255}`;
 }
@@ -40,7 +38,7 @@ function getCidr(start: string, end: string) {
   return { start: newStart, end: newEnd, mask };
 }
 
-function calculateCidr({ startIp, endIp }: { startIp: string; endIp: string }) {
+export function calculateCidr({ startIp, endIp }: { startIp: string; endIp: string }) {
   const start = convertBase({
     value: ipv4ToInt({ ip: startIp }).toString(),
     fromBase: 10,

--- a/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.service.ts
+++ b/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.service.ts
@@ -1,11 +1,9 @@
 import { Netmask } from 'netmask';
 
-export { getNetworkInfo, getNetworkMaskInBinary };
-
-function getNetworkInfo(address: string) {
+export function getNetworkInfo(address: string) {
   return new Netmask(address.trim());
 }
 
-function getNetworkMaskInBinary({ bitmask }: { bitmask: number }): string {
+export function getNetworkMaskInBinary({ bitmask }: { bitmask: number }): string {
   return ('1'.repeat(bitmask) + '0'.repeat(32 - bitmask)).match(/.{8}/g)?.join('.') ?? '';
 }

--- a/src/tools/ipv6-ula-generator/ipv6-ula-generator.service.ts
+++ b/src/tools/ipv6-ula-generator/ipv6-ula-generator.service.ts
@@ -1,9 +1,7 @@
 import { sha1 } from '@awasm/noble';
 import { bytesToHex, utf8ToBytes } from '@awasm/noble/utils.js';
 
-export { generateUla };
-
-function generateUla({ macAddress, timestamp = Date.now() }: { macAddress: string; timestamp?: number }) {
+export function generateUla({ macAddress, timestamp = Date.now() }: { macAddress: string; timestamp?: number }) {
   // RFC 4193 section 3.2.2 mandates SHA-1 for deriving the ULA Global ID;
   // this is pseudo-random ID generation, not a security control.
   const hex40bit = bytesToHex(sha1(utf8ToBytes(`${timestamp}${macAddress}`)))

--- a/src/tools/json-minify/json-minify.service.ts
+++ b/src/tools/json-minify/json-minify.service.ts
@@ -1,7 +1,5 @@
 import JSON5 from 'json5';
 
-export { minifyJson };
-
-function minifyJson(rawJson: string): string {
+export function minifyJson(rawJson: string): string {
   return JSON.stringify(JSON5.parse(rawJson), null, 0);
 }

--- a/src/tools/json-sort-keys/json-sort-keys.service.ts
+++ b/src/tools/json-sort-keys/json-sort-keys.service.ts
@@ -1,7 +1,5 @@
 import JSON5 from 'json5';
 
-export { sortJsonKeys };
-
 interface SortOptions {
   order?: 'asc' | 'desc';
   indent?: number;
@@ -26,7 +24,7 @@ function sortValue(value: unknown, order: 'asc' | 'desc'): unknown {
 
 // Parse JSON (JSON5-tolerant) and re-serialize it with every object's keys
 // sorted recursively, producing a canonical output useful for diffing.
-function sortJsonKeys(json: string, { order = 'asc', indent = 2 }: SortOptions = {}): string {
+export function sortJsonKeys(json: string, { order = 'asc', indent = 2 }: SortOptions = {}): string {
   const parsed = JSON5.parse(json);
   return JSON.stringify(sortValue(parsed, order), null, indent);
 }

--- a/src/tools/json-to-csv/json-to-csv.service.ts
+++ b/src/tools/json-to-csv/json-to-csv.service.ts
@@ -1,6 +1,4 @@
-export { convertArrayToCsv, getHeaders };
-
-function getHeaders({ array }: { array: Record<string, unknown>[] }): string[] {
+export function getHeaders({ array }: { array: Record<string, unknown>[] }): string[] {
   const headers = new Set<string>();
 
   array.forEach(item => Object.keys(item).forEach(key => headers.add(key)));
@@ -26,7 +24,7 @@ function serializeValue(value: unknown): string {
   return valueAsString;
 }
 
-function convertArrayToCsv({ array }: { array: Record<string, unknown>[] }): string {
+export function convertArrayToCsv({ array }: { array: Record<string, unknown>[] }): string {
   const headers = getHeaders({ array });
 
   const rows = array.map(item => headers.map(header => serializeValue(item[header])));

--- a/src/tools/json-to-toml/json-to-toml.service.ts
+++ b/src/tools/json-to-toml/json-to-toml.service.ts
@@ -1,8 +1,6 @@
 import JSON5 from 'json5';
 import { stringify as stringifyToml } from 'smol-toml';
 
-export { convertJsonToToml };
-
-function convertJsonToToml(rawJson: string): string {
+export function convertJsonToToml(rawJson: string): string {
   return [stringifyToml(JSON5.parse(rawJson))].flat().join('\n').trim();
 }

--- a/src/tools/json-to-typescript/json-to-typescript.service.ts
+++ b/src/tools/json-to-typescript/json-to-typescript.service.ts
@@ -1,9 +1,7 @@
 import JSON5 from 'json5';
 import JsonToTS from 'json-to-ts';
 
-export { convertJsonToTypescript };
-
-function convertJsonToTypescript(json: string, { rootName = 'RootObject' }: { rootName?: string } = {}): string {
+export function convertJsonToTypescript(json: string, { rootName = 'RootObject' }: { rootName?: string } = {}): string {
   const parsed = JSON5.parse(json);
 
   if (typeof parsed !== 'object' || parsed === null) {

--- a/src/tools/json-to-xml/json-to-xml.service.ts
+++ b/src/tools/json-to-xml/json-to-xml.service.ts
@@ -1,8 +1,6 @@
 import JSON5 from 'json5';
 import convert from 'xml-js';
 
-export { convertJsonToXml };
-
-function convertJsonToXml(rawJson: string): string {
+export function convertJsonToXml(rawJson: string): string {
   return convert.js2xml(JSON5.parse(rawJson), { compact: true });
 }

--- a/src/tools/json-to-yaml-converter/json-to-yaml-converter.service.ts
+++ b/src/tools/json-to-yaml-converter/json-to-yaml-converter.service.ts
@@ -1,8 +1,6 @@
 import JSON5 from 'json5';
 import { stringify as stringifyYaml } from 'yaml';
 
-export { convertJsonToYaml };
-
-function convertJsonToYaml(rawJson: string): string {
+export function convertJsonToYaml(rawJson: string): string {
   return stringifyYaml(JSON5.parse(rawJson));
 }

--- a/src/tools/jsonpath-query/jsonpath-query.service.ts
+++ b/src/tools/jsonpath-query/jsonpath-query.service.ts
@@ -1,9 +1,7 @@
 import JSON5 from 'json5';
 import { evaluateJsonPath } from './jsonpath.engine';
 
-export { queryJson };
-
-function queryJson({ data, query, indentSize = 2 }: { data: string; query: string; indentSize?: number }): string {
+export function queryJson({ data, query, indentSize = 2 }: { data: string; query: string; indentSize?: number }): string {
   if (data.trim() === '') {
     return '';
   }

--- a/src/tools/jwt-generator/jwt-generator.service.ts
+++ b/src/tools/jwt-generator/jwt-generator.service.ts
@@ -1,16 +1,13 @@
 import { importPKCS8, SignJWT } from 'jose';
 
-export { isSymmetric, signJwt, SUPPORTED_ALGORITHMS };
-export type { JwtAlgorithm };
-
-type JwtAlgorithm
+export type JwtAlgorithm
   = | 'HS256' | 'HS384' | 'HS512'
     | 'RS256' | 'RS384' | 'RS512'
     | 'PS256' | 'PS384' | 'PS512'
     | 'ES256' | 'ES384' | 'ES512'
     | 'EdDSA';
 
-const SUPPORTED_ALGORITHMS: JwtAlgorithm[] = [
+export const SUPPORTED_ALGORITHMS: JwtAlgorithm[] = [
   'HS256',
   'HS384',
   'HS512',
@@ -27,11 +24,11 @@ const SUPPORTED_ALGORITHMS: JwtAlgorithm[] = [
 ];
 
 // HMAC algorithms sign with a shared secret; everything else needs a private key.
-function isSymmetric(algorithm: string): boolean {
+export function isSymmetric(algorithm: string): boolean {
   return algorithm.startsWith('HS');
 }
 
-async function signJwt({
+export async function signJwt({
   payload,
   algorithm,
   key,

--- a/src/tools/jwt-parser/jwt-parser.service.ts
+++ b/src/tools/jwt-parser/jwt-parser.service.ts
@@ -3,9 +3,7 @@ import { jwtDecode } from 'jwt-decode';
 import _ from 'lodash';
 import { ALGORITHM_DESCRIPTIONS, CLAIM_DESCRIPTIONS } from './jwt-parser.constants';
 
-export { decodeJwt };
-
-function decodeJwt({ jwt }: { jwt: string }) {
+export function decodeJwt({ jwt }: { jwt: string }) {
   const rawHeader = jwtDecode<JwtHeader>(jwt, { header: true });
   const rawPayload = jwtDecode<JwtPayload>(jwt);
 

--- a/src/tools/keycode-info/keycode-info.service.ts
+++ b/src/tools/keycode-info/keycode-info.service.ts
@@ -11,9 +11,7 @@ export interface KeyCodeInfo {
   modifiers: string;
 }
 
-export { formatModifiers, getKeyCodeInfo };
-
-function formatModifiers(event: Pick<KeyboardEventLike, 'metaKey' | 'shiftKey' | 'ctrlKey' | 'altKey'>): string {
+export function formatModifiers(event: Pick<KeyboardEventLike, 'metaKey' | 'shiftKey' | 'ctrlKey' | 'altKey'>): string {
   return [
     event.metaKey && 'Meta',
     event.shiftKey && 'Shift',
@@ -24,7 +22,7 @@ function formatModifiers(event: Pick<KeyboardEventLike, 'metaKey' | 'shiftKey' |
     .join(' + ');
 }
 
-function getKeyCodeInfo(event: KeyboardEventLike): KeyCodeInfo {
+export function getKeyCodeInfo(event: KeyboardEventLike): KeyCodeInfo {
   return {
     key: event.key,
     keyCode: String(event.keyCode),

--- a/src/tools/mac-address-lookup/mac-address-lookup.service.ts
+++ b/src/tools/mac-address-lookup/mac-address-lookup.service.ts
@@ -6,20 +6,18 @@ import ouiDataUrl from 'oui-data?url';
 
 export type OuiData = Record<string, string>;
 
-export { getVendorValue, loadOuiData, lookupMacAddressVendor };
-
 let ouiDataPromise: Promise<OuiData> | undefined;
 
 // Memoised: the database is fetched and parsed at most once per session.
-function loadOuiData(): Promise<OuiData> {
+export function loadOuiData(): Promise<OuiData> {
   ouiDataPromise ??= fetch(ouiDataUrl).then(response => response.json() as Promise<OuiData>);
   return ouiDataPromise;
 }
 
-function getVendorValue(address: string): string {
+export function getVendorValue(address: string): string {
   return address.trim().replace(/[.:-]/g, '').toUpperCase().substring(0, 6);
 }
 
-function lookupMacAddressVendor(db: OuiData, address: string): string | undefined {
+export function lookupMacAddressVendor(db: OuiData, address: string): string | undefined {
   return db[getVendorValue(address)];
 }

--- a/src/tools/markdown-editor/markdown-editor.service.ts
+++ b/src/tools/markdown-editor/markdown-editor.service.ts
@@ -1,15 +1,13 @@
 import DOMPurify from 'dompurify';
 import markdownit from 'markdown-it';
 
-export { renderMarkdownToHtml, renderMarkdownToSafeHtml };
-
-function renderMarkdownToHtml(markdown: string): string {
+export function renderMarkdownToHtml(markdown: string): string {
   const md = markdownit({ html: true, linkify: true, typographer: true, breaks: true });
   return md.render(markdown);
 }
 
 // Preview is injected with v-html, so raw HTML authored in the markdown must be
 // sanitized before it reaches the DOM.
-function renderMarkdownToSafeHtml(markdown: string): string {
+export function renderMarkdownToSafeHtml(markdown: string): string {
   return DOMPurify.sanitize(renderMarkdownToHtml(markdown));
 }

--- a/src/tools/markdown-to-html/markdown-to-html.service.ts
+++ b/src/tools/markdown-to-html/markdown-to-html.service.ts
@@ -1,8 +1,6 @@
 import markdownit from 'markdown-it';
 
-export { convertMarkdownToHtml };
-
-function convertMarkdownToHtml(markdown: string): string {
+export function convertMarkdownToHtml(markdown: string): string {
   const md = markdownit();
   return md.render(markdown);
 }

--- a/src/tools/markdown-toc-generator/markdown-toc-generator.service.ts
+++ b/src/tools/markdown-toc-generator/markdown-toc-generator.service.ts
@@ -1,7 +1,4 @@
-export { generateToc, slugify };
-export type { TocOptions };
-
-interface TocOptions {
+export interface TocOptions {
   // Only include headings between these levels (inclusive).
   minLevel?: number;
   maxLevel?: number;
@@ -19,7 +16,7 @@ interface Heading {
 
 // GitHub-style anchor slug: lowercase, spaces to hyphens, drop characters that
 // are not word characters/hyphens/spaces.
-function slugify(text: string): string {
+export function slugify(text: string): string {
   return text
     .trim()
     .toLowerCase()
@@ -67,7 +64,7 @@ function parseHeadings(markdown: string): Heading[] {
   return headings;
 }
 
-function generateToc(markdown: string, options: TocOptions = {}): string {
+export function generateToc(markdown: string, options: TocOptions = {}): string {
   const { minLevel = 1, maxLevel = 6, indent = '  ', bullet = '-' } = options;
 
   const headings = parseHeadings(markdown).filter(

--- a/src/tools/math-evaluator/math-evaluator.service.ts
+++ b/src/tools/math-evaluator/math-evaluator.service.ts
@@ -1,7 +1,5 @@
 import { evaluate } from 'mathjs';
 
-export { evaluateMathExpression };
-
-function evaluateMathExpression(expression: string) {
+export function evaluateMathExpression(expression: string) {
   return evaluate(expression) ?? '';
 }

--- a/src/tools/meta-tag-generator/meta-tag-generator.service.ts
+++ b/src/tools/meta-tag-generator/meta-tag-generator.service.ts
@@ -2,9 +2,7 @@ import type { MetadataConfig } from './oggen';
 import _ from 'lodash';
 import { generateMeta } from './oggen';
 
-export { generateMetaTags };
-
-function generateMetaTags(metadata: Record<string, unknown>): string {
+export function generateMetaTags(metadata: Record<string, unknown>): string {
   const twitterMeta = _.chain(metadata)
     .pickBy((_value, k) => k.startsWith('twitter:'))
     .mapKeys((_value, k) => k.replace(/^twitter:/, ''))

--- a/src/tools/mime-types/mime-types.service.ts
+++ b/src/tools/mime-types/mime-types.service.ts
@@ -1,29 +1,21 @@
 import { types as extensionToMimeType, extensions as mimeTypeToExtension } from 'mime-types';
 
-export {
-  getExtensionsFromMimeType,
-  getExtensionToMimeTypeOptions,
-  getMimeInfos,
-  getMimeTypeFromExtension,
-  getMimeTypeToExtensionOptions,
-};
-
-function getMimeInfos(): { mimeType: string; extensions: string[] }[] {
+export function getMimeInfos(): { mimeType: string; extensions: string[] }[] {
   return Object.entries(mimeTypeToExtension).map(([mimeType, extensions]) => ({ mimeType, extensions }));
 }
 
-function getMimeTypeToExtensionOptions(): { label: string; value: string }[] {
+export function getMimeTypeToExtensionOptions(): { label: string; value: string }[] {
   return Object.keys(mimeTypeToExtension).map(label => ({ label, value: label }));
 }
 
-function getExtensionToMimeTypeOptions(): { label: string; value: string }[] {
+export function getExtensionToMimeTypeOptions(): { label: string; value: string }[] {
   return Object.keys(extensionToMimeType).map(label => ({ label: `.${label}`, value: label }));
 }
 
-function getExtensionsFromMimeType(mimeType: string): string[] {
+export function getExtensionsFromMimeType(mimeType: string): string[] {
   return mimeTypeToExtension[mimeType] ?? [];
 }
 
-function getMimeTypeFromExtension(extension: string): string | undefined {
+export function getMimeTypeFromExtension(extension: string): string | undefined {
   return extensionToMimeType[extension];
 }

--- a/src/tools/number-to-words/number-to-words.service.ts
+++ b/src/tools/number-to-words/number-to-words.service.ts
@@ -1,5 +1,3 @@
-export { numberToWords };
-
 const ONES = [
   'zero',
   'one',
@@ -84,7 +82,7 @@ function integerToWords(digits: string): string {
 // Convert a number (or numeric string) into its English words representation.
 // Supports negatives and decimals; decimal digits are read out individually
 // (e.g. 3.14 -> "three point one four").
-function numberToWords(input: number | string): string {
+export function numberToWords(input: number | string): string {
   const raw = typeof input === 'number' ? input.toString() : input.trim();
 
   if (raw === '' || !/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/.test(raw)) {

--- a/src/tools/numeronym-generator/numeronym-generator.service.ts
+++ b/src/tools/numeronym-generator/numeronym-generator.service.ts
@@ -1,6 +1,4 @@
-export { generateNumeronym };
-
-function generateNumeronym(word: string): string {
+export function generateNumeronym(word: string): string {
   const wordLength = word.length;
 
   if (wordLength <= 3) {

--- a/src/tools/ocr-image-to-text/ocr-image-to-text.service.ts
+++ b/src/tools/ocr-image-to-text/ocr-image-to-text.service.ts
@@ -1,27 +1,24 @@
 import { createWorker } from 'tesseract.js';
 
-export { createRecognizer, getAssetsBaseUrl, recognizeText, resolveAssetsBase, SUPPORTED_LANGUAGES };
-export type { OcrImage, OcrLanguage, OcrProgress, OcrQuality, Recognizer };
-
-interface OcrLanguage {
+export interface OcrLanguage {
   code: string;
   name: string;
 }
 
 // Anything tesseract.js' recognize() accepts.
-type OcrImage = File | Blob | string;
+export type OcrImage = File | Blob | string;
 
-interface OcrProgress {
+export interface OcrProgress {
   status: string;
   progress: number;
 }
 
 // fast = tessdata_fast (smaller/faster, the default); best = tessdata_best
 // (larger, slower, higher accuracy). Selects which tessdata directory to load.
-type OcrQuality = 'fast' | 'best';
+export type OcrQuality = 'fast' | 'best';
 
 // A worker created once and reused across a batch of images, then terminated.
-interface Recognizer {
+export interface Recognizer {
   recognize: (image: OcrImage) => Promise<string>;
   terminate: () => Promise<void>;
 }
@@ -33,7 +30,7 @@ interface Recognizer {
 // VITE_OCR_ASSETS_BASE_URL override always wins - that origin must then be
 // allowed by the CSP connect-src/script-src. The path is versioned by the
 // tesseract.js version so the engine and its WASM core stay in lockstep.
-function resolveAssetsBase({ prod, override }: { prod: boolean; override?: string }): string {
+export function resolveAssetsBase({ prod, override }: { prod: boolean; override?: string }): string {
   const fallback = prod ? 'https://assets.thetech.network' : '';
   return (override ?? fallback).replace(/\/+$/, '');
 }
@@ -41,13 +38,13 @@ function resolveAssetsBase({ prod, override }: { prod: boolean; override?: strin
 const ASSETS_BASE = resolveAssetsBase({ prod: import.meta.env.PROD, override: import.meta.env.VITE_OCR_ASSETS_BASE_URL });
 const ASSETS_VERSION = import.meta.env.TESSERACT_VERSION;
 
-function getAssetsBaseUrl(): string {
+export function getAssetsBaseUrl(): string {
   return `${ASSETS_BASE}/tesseract/${ASSETS_VERSION}`;
 }
 
 // Languages offered in the UI. Codes are Tesseract language codes and must match
 // what the sync script uploads to the asset host.
-const SUPPORTED_LANGUAGES: OcrLanguage[] = [
+export const SUPPORTED_LANGUAGES: OcrLanguage[] = [
   { code: 'eng', name: 'English' },
   { code: 'spa', name: 'Spanish' },
   { code: 'fra', name: 'French' },
@@ -108,7 +105,7 @@ async function assertLanguageAvailable(url: string, language: string): Promise<v
 // Create one worker for the given languages/quality and reuse it across many
 // images before terminating - much faster than re-initializing per image when
 // processing a batch (or the pages of a PDF).
-async function createRecognizer({
+export async function createRecognizer({
   languages,
   quality = 'fast',
   onProgress,
@@ -144,7 +141,7 @@ async function createRecognizer({
 }
 
 // Recognize a single image (creates a worker, recognizes, terminates).
-async function recognizeText({
+export async function recognizeText({
   image,
   languages,
   quality,

--- a/src/tools/otp-code-generator-and-validator/otp-code-generator-and-validator.service.ts
+++ b/src/tools/otp-code-generator-and-validator/otp-code-generator-and-validator.service.ts
@@ -4,19 +4,7 @@ import { bytesToHex } from '@awasm/noble/utils.js';
 import _ from 'lodash';
 import { createToken } from '../token-generator/token-generator.service';
 
-export {
-  base32toHex,
-  buildKeyUri,
-  generateHOTP,
-  generateSecret,
-  generateTOTP,
-  getCounterFromTime,
-  hexToBytes,
-  verifyHOTP,
-  verifyTOTP,
-};
-
-function hexToBytes(hex: string) {
+export function hexToBytes(hex: string) {
   return (hex.match(/.{1,2}/g) ?? []).map(char => Number.parseInt(char, 16));
 }
 
@@ -25,7 +13,7 @@ function computeHMACSha1(message: string, key: string) {
   return bytesToHex(hmac(sha1, Uint8Array.from(hexToBytes(base32toHex(key))), Uint8Array.from(hexToBytes(message))));
 }
 
-function base32toHex(base32: string) {
+export function base32toHex(base32: string) {
   const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
   const bits = base32
@@ -40,7 +28,7 @@ function base32toHex(base32: string) {
   return hex;
 }
 
-function generateHOTP({ key, counter = 0 }: { key: string; counter?: number }) {
+export function generateHOTP({ key, counter = 0 }: { key: string; counter?: number }) {
   // Compute HMACdigest
   const digest = computeHMACSha1(counter.toString(16).padStart(16, '0'), key);
 
@@ -60,7 +48,7 @@ function generateHOTP({ key, counter = 0 }: { key: string; counter?: number }) {
   return code;
 }
 
-function verifyHOTP({
+export function verifyHOTP({
   token,
   key,
   window = 0,
@@ -80,17 +68,17 @@ function verifyHOTP({
   return false;
 }
 
-function getCounterFromTime({ now, timeStep }: { now: number; timeStep: number }) {
+export function getCounterFromTime({ now, timeStep }: { now: number; timeStep: number }) {
   return Math.floor(now / 1000 / timeStep);
 }
 
-function generateTOTP({ key, now = Date.now(), timeStep = 30 }: { key: string; now?: number; timeStep?: number }) {
+export function generateTOTP({ key, now = Date.now(), timeStep = 30 }: { key: string; now?: number; timeStep?: number }) {
   const counter = getCounterFromTime({ now, timeStep });
 
   return generateHOTP({ key, counter });
 }
 
-function verifyTOTP({
+export function verifyTOTP({
   key,
   token,
   window = 0,
@@ -108,7 +96,7 @@ function verifyTOTP({
   return verifyHOTP({ token, key, window, counter });
 }
 
-function buildKeyUri({
+export function buildKeyUri({
   secret,
   app = 'IT-Tools',
   account = 'demo-user',
@@ -138,6 +126,6 @@ function buildKeyUri({
   return `otpauth://totp/${encodeURIComponent(app)}:${encodeURIComponent(account)}?${paramsString}`;
 }
 
-function generateSecret() {
+export function generateSecret() {
   return createToken({ length: 16, alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567' });
 }

--- a/src/tools/password-strength-analyser/password-strength-analyser.service.ts
+++ b/src/tools/password-strength-analyser/password-strength-analyser.service.ts
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 
-export { getCharsetLength, getPasswordCrackTimeEstimation };
-
 function prettifyExponentialNotation(exponentialNotation: number) {
   const [base, exponent] = exponentialNotation.toString().split('e');
   const baseAsNumber = Number.parseFloat(base ?? '0');
@@ -49,7 +47,7 @@ function getHumanFriendlyDuration({ seconds }: { seconds: number }) {
     .value();
 }
 
-function getPasswordCrackTimeEstimation({ password, guessesPerSecond = 1e9 }: { password: string; guessesPerSecond?: number }) {
+export function getPasswordCrackTimeEstimation({ password, guessesPerSecond = 1e9 }: { password: string; guessesPerSecond?: number }) {
   const charsetLength = getCharsetLength({ password });
   const passwordLength = password.length;
 
@@ -71,7 +69,7 @@ function getPasswordCrackTimeEstimation({ password, guessesPerSecond = 1e9 }: { 
   };
 }
 
-function getCharsetLength({ password }: { password: string }) {
+export function getCharsetLength({ password }: { password: string }) {
   const hasLowercase = /[a-z]/.test(password);
   const hasUppercase = /[A-Z]/.test(password);
   const hasDigits = /\d/.test(password);

--- a/src/tools/pdf-signature-checker/pdf-signature-checker.service.ts
+++ b/src/tools/pdf-signature-checker/pdf-signature-checker.service.ts
@@ -1,7 +1,5 @@
 import type { SignatureInfo } from './pdf-signature-checker.types';
 
-export { formatCertificates };
-
 type Certificate = SignatureInfo['meta']['certs'][number];
 
 type FormattedCertificate = Certificate & {
@@ -16,7 +14,7 @@ type FormattedCertificate = Certificate & {
 // the injected `formatDate` (locale-sensitive when using toLocaleString in the UI,
 // so it is passed in to keep this function pure and testable) and each row gets a
 // 1-based name from `formatCertificateName`.
-function formatCertificates({
+export function formatCertificates({
   certs,
   formatDate,
   formatCertificateName,

--- a/src/tools/percentage-calculator/percentage-calculator.service.ts
+++ b/src/tools/percentage-calculator/percentage-calculator.service.ts
@@ -1,15 +1,13 @@
-export { calculatePercentageChange, calculatePercentageOfNumber, calculateWhatPercentageOf };
-
-function calculatePercentageOfNumber({ percentage, value }: { percentage: number; value: number }): string {
+export function calculatePercentageOfNumber({ percentage, value }: { percentage: number; value: number }): string {
   return (percentage / 100 * value).toString();
 }
 
-function calculateWhatPercentageOf({ value, total }: { value: number; total: number }): string {
+export function calculateWhatPercentageOf({ value, total }: { value: number; total: number }): string {
   const result = 100 * value / total;
   return (!Number.isFinite(result) || Number.isNaN(result)) ? '' : result.toString();
 }
 
-function calculatePercentageChange({ from, to }: { from: number; to: number }): string {
+export function calculatePercentageChange({ from, to }: { from: number; to: number }): string {
   const result = (to - from) / from * 100;
   return (!Number.isFinite(result) || Number.isNaN(result)) ? '' : result.toString();
 }

--- a/src/tools/phone-parser-and-formatter/phone-parser-and-formatter.service.ts
+++ b/src/tools/phone-parser-and-formatter/phone-parser-and-formatter.service.ts
@@ -3,8 +3,6 @@ import lookup from 'country-code-lookup';
 import { parsePhoneNumber } from 'libphonenumber-js/max';
 import { booleanToHumanReadable } from '@/utils/boolean';
 
-export { formatTypeToHumanReadable, getDefaultCountryCode, getFullCountryName, parsePhoneNumberDetails };
-
 const typeToLabel: Record<NonNullable<NumberType>, string> = {
   MOBILE: 'Mobile',
   FIXED_LINE: 'Fixed line',
@@ -19,7 +17,7 @@ const typeToLabel: Record<NonNullable<NumberType>, string> = {
   PAGER: 'Pager',
 };
 
-function formatTypeToHumanReadable(type: NumberType): string | undefined {
+export function formatTypeToHumanReadable(type: NumberType): string | undefined {
   if (!type) {
     return undefined;
   }
@@ -27,7 +25,7 @@ function formatTypeToHumanReadable(type: NumberType): string | undefined {
   return typeToLabel[type];
 }
 
-function getFullCountryName(countryCode: string | undefined) {
+export function getFullCountryName(countryCode: string | undefined) {
   if (!countryCode) {
     return undefined;
   }
@@ -35,7 +33,7 @@ function getFullCountryName(countryCode: string | undefined) {
   return lookup.byIso(countryCode)?.country;
 }
 
-function getDefaultCountryCode({
+export function getDefaultCountryCode({
   locale = window.navigator.language,
   defaultCode = 'FR',
 }: { locale?: string; defaultCode?: CountryCode } = {}): CountryCode {
@@ -48,7 +46,7 @@ function getDefaultCountryCode({
   return (lookup.byIso(countryCode)?.iso2 ?? defaultCode) as CountryCode;
 }
 
-function parsePhoneNumberDetails({ phoneNumber, defaultCountryCode }: { phoneNumber: string; defaultCountryCode?: CountryCode }) {
+export function parsePhoneNumberDetails({ phoneNumber, defaultCountryCode }: { phoneNumber: string; defaultCountryCode?: CountryCode }) {
   const parsed = parsePhoneNumber(phoneNumber, defaultCountryCode);
 
   return [

--- a/src/tools/qr-code-generator/qr-code-generator.service.ts
+++ b/src/tools/qr-code-generator/qr-code-generator.service.ts
@@ -1,9 +1,7 @@
 import type { QRCodeErrorCorrectionLevel, QRCodeToDataURLOptions } from 'qrcode';
 import QRCode from 'qrcode';
 
-export { createQRCodeDataUrl };
-
-function createQRCodeDataUrl({
+export function createQRCodeDataUrl({
   text,
   foreground,
   background,

--- a/src/tools/rsa-key-pair-generator/rsa-key-pair-generator.service.ts
+++ b/src/tools/rsa-key-pair-generator/rsa-key-pair-generator.service.ts
@@ -1,8 +1,6 @@
 import { pki } from 'node-forge';
 import workerScript from 'node-forge/dist/prime.worker.min?url';
 
-export { generateKeyPair };
-
 function generateRawPairs({ bits = 2048 }) {
   return new Promise<pki.rsa.KeyPair>((resolve, reject) =>
     pki.rsa.generateKeyPair({ bits, workerScript }, (err, keyPair) => {
@@ -16,7 +14,7 @@ function generateRawPairs({ bits = 2048 }) {
   );
 }
 
-async function generateKeyPair(config: { bits?: number } = {}) {
+export async function generateKeyPair(config: { bits?: number } = {}) {
   const { privateKey, publicKey } = await generateRawPairs(config);
 
   return {

--- a/src/tools/slugify-string/slugify-string.service.ts
+++ b/src/tools/slugify-string/slugify-string.service.ts
@@ -1,8 +1,6 @@
 import slugify from '@sindresorhus/slugify';
 
-export { slugifyString };
-
-function slugifyString(
+export function slugifyString(
   input: string,
   { separator = '-', lowercase = true }: { separator?: string; lowercase?: boolean } = {},
 ): string {

--- a/src/tools/sql-prettify/sql-prettify.service.ts
+++ b/src/tools/sql-prettify/sql-prettify.service.ts
@@ -1,8 +1,6 @@
 import type { FormatOptionsWithLanguage } from 'sql-formatter';
 import { format } from 'sql-formatter';
 
-export { formatSql };
-
-function formatSql(rawSql: string, options: FormatOptionsWithLanguage): string {
+export function formatSql(rawSql: string, options: FormatOptionsWithLanguage): string {
   return format(rawSql, options);
 }

--- a/src/tools/string-escape/string-escape.service.ts
+++ b/src/tools/string-escape/string-escape.service.ts
@@ -1,5 +1,3 @@
-export { escapeString, unescapeString };
-
 const ESCAPE_MAP: Record<string, string> = {
   '\\': '\\\\',
   '"': '\\"',
@@ -13,7 +11,7 @@ const ESCAPE_MAP: Record<string, string> = {
 // Escape a raw string into its backslash-escaped form (as it would appear
 // inside a double-quoted JSON/JS string literal, without the surrounding
 // quotes). Control characters below 0x20 become \uXXXX escapes.
-function escapeString(input: string): string {
+export function escapeString(input: string): string {
   let output = '';
 
   for (const char of input) {
@@ -36,7 +34,7 @@ function escapeString(input: string): string {
 
 // Reverse of escapeString: turn a backslash-escaped string back into its raw
 // form. Supports \\, \", \/, \b, \f, \n, \r, \t, \uXXXX and \xXX escapes.
-function unescapeString(input: string): string {
+export function unescapeString(input: string): string {
   let output = '';
   let i = 0;
 

--- a/src/tools/svg-placeholder-generator/svg-placeholder-generator.service.ts
+++ b/src/tools/svg-placeholder-generator/svg-placeholder-generator.service.ts
@@ -1,8 +1,6 @@
 import { textToBase64 } from '@/utils/base64';
 
-export { generateSvgPlaceholder, svgToBase64DataUrl };
-
-function generateSvgPlaceholder({
+export function generateSvgPlaceholder({
   width,
   height,
   fontSize,
@@ -30,6 +28,6 @@ function generateSvgPlaceholder({
   `.trim();
 }
 
-function svgToBase64DataUrl(svgString: string): string {
+export function svgToBase64DataUrl(svgString: string): string {
   return `data:image/svg+xml;base64,${textToBase64(svgString)}`;
 }

--- a/src/tools/temperature-converter/temperature-converter.service.ts
+++ b/src/tools/temperature-converter/temperature-converter.service.ts
@@ -1,37 +1,20 @@
-export {
-  convertCelsiusToKelvin,
-  convertDelisleToKelvin,
-  convertFahrenheitToKelvin,
-  convertKelvinToCelsius,
-  convertKelvinToDelisle,
-  convertKelvinToFahrenheit,
-  convertKelvinToNewton,
-  convertKelvinToRankine,
-  convertKelvinToReaumur,
-  convertKelvinToRomer,
-  convertNewtonToKelvin,
-  convertRankineToKelvin,
-  convertReaumurToKelvin,
-  convertRomerToKelvin,
-};
+export const convertCelsiusToKelvin = (temperature: number) => temperature + 273.15;
+export const convertKelvinToCelsius = (temperature: number) => temperature - 273.15;
 
-const convertCelsiusToKelvin = (temperature: number) => temperature + 273.15;
-const convertKelvinToCelsius = (temperature: number) => temperature - 273.15;
+export const convertFahrenheitToKelvin = (temperature: number) => (temperature + 459.67) * (5 / 9);
+export const convertKelvinToFahrenheit = (temperature: number) => temperature * (9 / 5) - 459.67;
 
-const convertFahrenheitToKelvin = (temperature: number) => (temperature + 459.67) * (5 / 9);
-const convertKelvinToFahrenheit = (temperature: number) => temperature * (9 / 5) - 459.67;
+export const convertRankineToKelvin = (temperature: number) => temperature * (5 / 9);
+export const convertKelvinToRankine = (temperature: number) => temperature * (9 / 5);
 
-const convertRankineToKelvin = (temperature: number) => temperature * (5 / 9);
-const convertKelvinToRankine = (temperature: number) => temperature * (9 / 5);
+export const convertDelisleToKelvin = (temperature: number) => 373.15 - (2 / 3) * temperature;
+export const convertKelvinToDelisle = (temperature: number) => (3 / 2) * (373.15 - temperature);
 
-const convertDelisleToKelvin = (temperature: number) => 373.15 - (2 / 3) * temperature;
-const convertKelvinToDelisle = (temperature: number) => (3 / 2) * (373.15 - temperature);
+export const convertNewtonToKelvin = (temperature: number) => temperature * (100 / 33) + 273.15;
+export const convertKelvinToNewton = (temperature: number) => (temperature - 273.15) * (33 / 100);
 
-const convertNewtonToKelvin = (temperature: number) => temperature * (100 / 33) + 273.15;
-const convertKelvinToNewton = (temperature: number) => (temperature - 273.15) * (33 / 100);
+export const convertReaumurToKelvin = (temperature: number) => temperature * (5 / 4) + 273.15;
+export const convertKelvinToReaumur = (temperature: number) => (temperature - 273.15) * (4 / 5);
 
-const convertReaumurToKelvin = (temperature: number) => temperature * (5 / 4) + 273.15;
-const convertKelvinToReaumur = (temperature: number) => (temperature - 273.15) * (4 / 5);
-
-const convertRomerToKelvin = (temperature: number) => (temperature - 7.5) * (40 / 21) + 273.15;
-const convertKelvinToRomer = (temperature: number) => (temperature - 273.15) * (21 / 40) + 7.5;
+export const convertRomerToKelvin = (temperature: number) => (temperature - 7.5) * (40 / 21) + 273.15;
+export const convertKelvinToRomer = (temperature: number) => (temperature - 273.15) * (21 / 40) + 7.5;

--- a/src/tools/text-line-tools/text-line-tools.service.ts
+++ b/src/tools/text-line-tools/text-line-tools.service.ts
@@ -1,9 +1,6 @@
-export { applyLineOperations };
-export type { LineOperations, SortOrder };
+export type SortOrder = 'none' | 'asc' | 'desc' | 'shuffle';
 
-type SortOrder = 'none' | 'asc' | 'desc' | 'shuffle';
-
-interface LineOperations {
+export interface LineOperations {
   trim: boolean;
   removeEmpty: boolean;
   unique: boolean;
@@ -35,7 +32,7 @@ function seededShuffle(lines: string[]): string[] {
   return result;
 }
 
-function applyLineOperations(text: string, operations: LineOperations): string {
+export function applyLineOperations(text: string, operations: LineOperations): string {
   if (text === '') {
     return '';
   }

--- a/src/tools/text-to-nato-alphabet/text-to-nato-alphabet.service.ts
+++ b/src/tools/text-to-nato-alphabet/text-to-nato-alphabet.service.ts
@@ -1,12 +1,10 @@
 import { natoAlphabet } from './text-to-nato-alphabet.constants';
 
-export { textToNatoAlphabet };
-
 function getLetterPositionInAlphabet({ letter }: { letter: string }) {
   return letter.toLowerCase().charCodeAt(0) - 'a'.charCodeAt(0);
 }
 
-function textToNatoAlphabet({ text }: { text: string }) {
+export function textToNatoAlphabet({ text }: { text: string }) {
   return text
     .split('')
     .map((character) => {

--- a/src/tools/text-to-unicode/text-to-unicode.service.ts
+++ b/src/tools/text-to-unicode/text-to-unicode.service.ts
@@ -1,9 +1,7 @@
-function convertTextToUnicode(text: string): string {
+export function convertTextToUnicode(text: string): string {
   return text.split('').map(value => `&#${value.charCodeAt(0)};`).join('');
 }
 
-function convertUnicodeToText(unicodeStr: string): string {
+export function convertUnicodeToText(unicodeStr: string): string {
   return unicodeStr.replace(/&#(\d+);/g, (match, dec) => String.fromCharCode(dec));
 }
-
-export { convertTextToUnicode, convertUnicodeToText };

--- a/src/tools/token-generator/token-generator.service.ts
+++ b/src/tools/token-generator/token-generator.service.ts
@@ -1,6 +1,4 @@
-export { createToken };
-
-function createToken({
+export function createToken({
   withUppercase = true,
   withLowercase = true,
   withNumbers = true,

--- a/src/tools/toml-to-json/toml-to-json.service.ts
+++ b/src/tools/toml-to-json/toml-to-json.service.ts
@@ -1,12 +1,10 @@
 import { parse as parseToml } from 'smol-toml';
 import { isNotThrowing } from '@/utils/boolean';
 
-export { convertTomlToJson, isValidToml };
-
-function convertTomlToJson(rawToml: string): string {
+export function convertTomlToJson(rawToml: string): string {
   return JSON.stringify(parseToml(rawToml), null, 3);
 }
 
-function isValidToml(toml: string): boolean {
+export function isValidToml(toml: string): boolean {
   return isNotThrowing(() => parseToml(toml));
 }

--- a/src/tools/toml-to-yaml/toml-to-yaml.service.ts
+++ b/src/tools/toml-to-yaml/toml-to-yaml.service.ts
@@ -1,8 +1,6 @@
 import { parse as parseToml } from 'smol-toml';
 import { stringify as stringifyYaml } from 'yaml';
 
-export { convertTomlToYaml };
-
-function convertTomlToYaml(rawToml: string): string {
+export function convertTomlToYaml(rawToml: string): string {
   return stringifyYaml(parseToml(rawToml));
 }

--- a/src/tools/ulid-generator/ulid-generator.service.ts
+++ b/src/tools/ulid-generator/ulid-generator.service.ts
@@ -1,12 +1,9 @@
 import _ from 'lodash';
 import { ulid } from 'ulid';
 
-export { generateUlids };
-export type { UlidFormat };
+export type UlidFormat = 'raw' | 'json';
 
-type UlidFormat = 'raw' | 'json';
-
-function generateUlids({ amount = 1, format = 'raw' }: { amount?: number; format?: UlidFormat } = {}): string {
+export function generateUlids({ amount = 1, format = 'raw' }: { amount?: number; format?: UlidFormat } = {}): string {
   const ids = _.times(amount, () => ulid());
 
   if (format === 'json') {

--- a/src/tools/unicode-inspector/unicode-inspector.service.ts
+++ b/src/tools/unicode-inspector/unicode-inspector.service.ts
@@ -1,7 +1,4 @@
-export { inspectString };
-export type { CharacterInfo };
-
-interface CharacterInfo {
+export interface CharacterInfo {
   char: string;
   codePoint: number;
   // "U+0041" style notation.
@@ -53,7 +50,7 @@ function describe(codePoint: number): string {
 
 // Break a string into its Unicode code points (iterating by code point handles
 // surrogate pairs / emoji correctly) and describe each one.
-function inspectString(input: string): CharacterInfo[] {
+export function inspectString(input: string): CharacterInfo[] {
   return Array.from(input).map((char) => {
     const codePoint = char.codePointAt(0) ?? 0;
 

--- a/src/tools/url-encoder/url-encoder.service.ts
+++ b/src/tools/url-encoder/url-encoder.service.ts
@@ -1,9 +1,7 @@
-export { decodeUrlString, encodeUrlString };
-
-function encodeUrlString(text: string): string {
+export function encodeUrlString(text: string): string {
   return encodeURIComponent(text);
 }
 
-function decodeUrlString(encoded: string): string {
+export function decodeUrlString(encoded: string): string {
   return decodeURIComponent(encoded);
 }

--- a/src/tools/url-parser/url-parser.service.ts
+++ b/src/tools/url-parser/url-parser.service.ts
@@ -1,9 +1,7 @@
-export { getUrlSearchParamsEntries, parseUrl };
-
-function parseUrl(urlToParse: string): URL {
+export function parseUrl(urlToParse: string): URL {
   return new URL(urlToParse);
 }
 
-function getUrlSearchParamsEntries(url: URL | undefined): [string, string][] {
+export function getUrlSearchParamsEntries(url: URL | undefined): [string, string][] {
   return Object.entries(Object.fromEntries(url?.searchParams.entries() ?? []));
 }

--- a/src/tools/user-agent-parser/user-agent-parser.service.ts
+++ b/src/tools/user-agent-parser/user-agent-parser.service.ts
@@ -1,11 +1,9 @@
 import { UAParser } from 'ua-parser-js';
 
-export { getUserAgentInfo };
-
 // If no input in the ua field is present return an empty object of type UAParser.IResult because otherwise
 // UAParser returns the values for the current Browser. This is confusing because results are shown for an empty
 // UA field value.
-function getUserAgentInfo(userAgent: string): UAParser.IResult {
+export function getUserAgentInfo(userAgent: string): UAParser.IResult {
   return userAgent.trim().length > 0
     ? UAParser(userAgent.trim())
     : ({ ua: '', browser: {}, cpu: {}, device: {}, engine: {}, os: {} } as UAParser.IResult);

--- a/src/tools/uuid-generator/uuid-generator.service.ts
+++ b/src/tools/uuid-generator/uuid-generator.service.ts
@@ -9,20 +9,17 @@ import {
   validate as validateUuid,
 } from 'uuid';
 
-export { generateUuids, isValidUuid, uuidVersions };
-export type { UuidVersion };
+export const uuidVersions = ['NIL', 'v1', 'v3', 'v4', 'v5', 'v6', 'v7'] as const;
+export type UuidVersion = typeof uuidVersions[number];
 
-const uuidVersions = ['NIL', 'v1', 'v3', 'v4', 'v5', 'v6', 'v7'] as const;
-type UuidVersion = typeof uuidVersions[number];
-
-function isValidUuid(value: string): boolean {
+export function isValidUuid(value: string): boolean {
   // uuid's validate() accepts every RFC 9562 version (1-8) and the nil UUID,
   // so v6/v7 identifiers validate too (the old hand-rolled regex only allowed
   // versions 1-5).
   return validateUuid(value);
 }
 
-function generateUuids({
+export function generateUuids({
   version,
   count = 1,
   namespace = '',

--- a/src/tools/wifi-qr-code-generator/wifi-qr-code-generator.service.ts
+++ b/src/tools/wifi-qr-code-generator/wifi-qr-code-generator.service.ts
@@ -1,12 +1,9 @@
-export { EAPMethods, EAPPhase2Methods, escapeString, getQrCodeText, wifiEncryptions };
-export type { EAPMethod, EAPPhase2Method, GetQrCodeTextOptions, WifiEncryption };
-
-const wifiEncryptions = ['WEP', 'WPA', 'nopass', 'WPA2-EAP'] as const;
-type WifiEncryption = typeof wifiEncryptions[number];
+export const wifiEncryptions = ['WEP', 'WPA', 'nopass', 'WPA2-EAP'] as const;
+export type WifiEncryption = typeof wifiEncryptions[number];
 
 // @see https://en.wikipedia.org/wiki/Extensible_Authentication_Protocol
 // for a list of available EAP methods. There are a lot (40!) of them.
-const EAPMethods = [
+export const EAPMethods = [
   'MD5',
   'POTP',
   'GTC',
@@ -25,15 +22,15 @@ const EAPMethods = [
   'NOOB',
   'PEAP',
 ] as const;
-type EAPMethod = typeof EAPMethods[number];
+export type EAPMethod = typeof EAPMethods[number];
 
-const EAPPhase2Methods = [
+export const EAPPhase2Methods = [
   'None',
   'MSCHAPV2',
 ] as const;
-type EAPPhase2Method = typeof EAPPhase2Methods[number];
+export type EAPPhase2Method = typeof EAPPhase2Methods[number];
 
-interface GetQrCodeTextOptions {
+export interface GetQrCodeTextOptions {
   ssid: string;
   password: string;
   encryption: WifiEncryption;
@@ -44,12 +41,12 @@ interface GetQrCodeTextOptions {
   eapPhase2Method: EAPPhase2Method;
 }
 
-function escapeString(str: string) {
+export function escapeString(str: string) {
   // replaces \, ;, ,, " and : with the same character preceded by a backslash
   return str.replace(/([\\;,:"])/g, '\\$1');
 }
 
-function getQrCodeText(options: GetQrCodeTextOptions): string | null {
+export function getQrCodeText(options: GetQrCodeTextOptions): string | null {
   const { ssid, password, encryption, eapMethod, isHiddenSSID, eapAnonymous, eapIdentity, eapPhase2Method } = options;
   if (!ssid) {
     return null;

--- a/src/tools/x509-certificate-parser/x509-certificate-parser.service.ts
+++ b/src/tools/x509-certificate-parser/x509-certificate-parser.service.ts
@@ -1,9 +1,6 @@
 import { asn1, md, pki } from 'node-forge';
 
-export type { DistinguishedName, ParsedCertificate };
-export { describePublicKey, formatAltNames, formatHexColons, parseCertificate, parseDistinguishedName };
-
-interface DistinguishedName {
+export interface DistinguishedName {
   commonName?: string;
   organizationName?: string;
   organizationalUnitName?: string;
@@ -14,7 +11,7 @@ interface DistinguishedName {
   attributes: { shortName?: string; name?: string; value: string }[];
 }
 
-interface ParsedCertificate {
+export interface ParsedCertificate {
   subject: DistinguishedName;
   issuer: DistinguishedName;
   serialNumber: string;
@@ -51,11 +48,11 @@ const SHORT_NAME_TO_FIELD: Record<string, keyof Omit<DistinguishedName, 'attribu
 
 // Groups a lowercase hex digest into colon-separated, upper-cased byte pairs,
 // e.g. "ab12cd" -> "AB:12:CD" (the conventional fingerprint/serial display).
-function formatHexColons(hex: string): string {
+export function formatHexColons(hex: string): string {
   return (hex.match(/.{1,2}/g) ?? []).join(':').toUpperCase();
 }
 
-function parseDistinguishedName(attributes: { shortName?: string; name?: string; value?: unknown }[]): DistinguishedName {
+export function parseDistinguishedName(attributes: { shortName?: string; name?: string; value?: unknown }[]): DistinguishedName {
   const dn: DistinguishedName = { attributes: [] };
 
   for (const attribute of attributes) {
@@ -74,7 +71,7 @@ function parseDistinguishedName(attributes: { shortName?: string; name?: string;
 // Maps the raw subjectAltName entries to `<label>:<value>` strings (e.g.
 // "DNS:example.com", "IP:127.0.0.1"). Pure so it can be tested for every
 // GeneralName type without needing a certificate per case.
-function formatAltNames(altNames: { type: number; value?: string; ip?: string }[]): string[] {
+export function formatAltNames(altNames: { type: number; value?: string; ip?: string }[]): string[] {
   const typeLabels: Record<number, string> = { 1: 'email', 2: 'DNS', 6: 'URI', 7: 'IP' };
 
   return altNames.map((altName) => {
@@ -100,7 +97,7 @@ function getFingerprints(cert: pki.Certificate): { sha1: string; sha256: string 
 // node-forge fully models RSA keys (modulus `n`, exponent `e`); other key types
 // (e.g. EC) surface without those fields and are reported as "Unknown". Pure so
 // both branches are testable without an EC certificate fixture.
-function describePublicKey(publicKey: { n?: { bitLength: () => number }; e?: { toString: () => string } } | undefined): ParsedCertificate['publicKey'] {
+export function describePublicKey(publicKey: { n?: { bitLength: () => number }; e?: { toString: () => string } } | undefined): ParsedCertificate['publicKey'] {
   if (publicKey?.n && publicKey?.e) {
     return {
       algorithm: 'RSA',
@@ -123,7 +120,7 @@ function isSelfSigned(cert: pki.Certificate): boolean {
   }
 }
 
-function parseCertificate(pem: string): ParsedCertificate {
+export function parseCertificate(pem: string): ParsedCertificate {
   const trimmed = pem.trim();
   if (trimmed === '') {
     throw new Error('No certificate provided');

--- a/src/tools/xml-formatter/xml-formatter.service.ts
+++ b/src/tools/xml-formatter/xml-formatter.service.ts
@@ -2,17 +2,15 @@ import type { XMLFormatterOptions } from 'xml-formatter';
 import xmlFormat from 'xml-formatter';
 import { withDefaultOnError } from '@/utils/defaults';
 
-export { formatXml, isValidXML };
-
 function cleanRawXml(rawXml: string): string {
   return rawXml.trim();
 }
 
-function formatXml(rawXml: string, options?: XMLFormatterOptions): string {
+export function formatXml(rawXml: string, options?: XMLFormatterOptions): string {
   return withDefaultOnError(() => xmlFormat(cleanRawXml(rawXml), options) ?? '', '');
 }
 
-function isValidXML(rawXml: string): boolean {
+export function isValidXML(rawXml: string): boolean {
   const cleanedRawXml = cleanRawXml(rawXml);
 
   if (cleanedRawXml === '') {

--- a/src/tools/xml-to-json/xml-to-json.service.ts
+++ b/src/tools/xml-to-json/xml-to-json.service.ts
@@ -1,7 +1,5 @@
 import convert from 'xml-js';
 
-export { convertXmlToJson };
-
-function convertXmlToJson(rawXml: string): string {
+export function convertXmlToJson(rawXml: string): string {
   return JSON.stringify(convert.xml2js(rawXml, { compact: true }), null, 2);
 }

--- a/src/tools/yaml-to-json-converter/yaml-to-json-converter.service.ts
+++ b/src/tools/yaml-to-json-converter/yaml-to-json-converter.service.ts
@@ -1,8 +1,6 @@
 import { parse as parseYaml } from 'yaml';
 
-export { convertYamlToJson };
-
-function convertYamlToJson(rawYaml: string): string {
+export function convertYamlToJson(rawYaml: string): string {
   const obj = parseYaml(rawYaml, { merge: true });
   return obj ? JSON.stringify(obj, null, 3) : '';
 }

--- a/src/tools/yaml-to-toml/yaml-to-toml.service.ts
+++ b/src/tools/yaml-to-toml/yaml-to-toml.service.ts
@@ -1,8 +1,6 @@
 import { stringify as stringifyToml } from 'smol-toml';
 import { parse as parseYaml } from 'yaml';
 
-export { convertYamlToToml };
-
-function convertYamlToToml(rawYaml: string): string {
+export function convertYamlToToml(rawYaml: string): string {
   return [stringifyToml(parseYaml(rawYaml))].flat().join('\n').trim();
 }

--- a/src/tools/yaml-viewer/yaml-viewer.service.ts
+++ b/src/tools/yaml-viewer/yaml-viewer.service.ts
@@ -1,8 +1,6 @@
 import yaml from 'yaml';
 
-export { formatYaml };
-
-function formatYaml({
+export function formatYaml({
   rawYaml,
   sortKeys = false,
   indentSize = 2,

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,6 +1,4 @@
-export { byOrder };
-
-function byOrder({ order }: { order: 'asc' | 'desc' | null | undefined }) {
+export function byOrder({ order }: { order: 'asc' | 'desc' | null | undefined }) {
   return (a: string, b: string) => {
     return order === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
   };

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,13 +1,11 @@
 import { Base64 } from 'js-base64';
 
-export { base64ToText, isValidBase64, removePotentialDataAndMimePrefix, textToBase64 };
-
-function textToBase64(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
+export function textToBase64(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
   const encoded = Base64.encode(str);
   return makeUrlSafe ? makeUriSafe(encoded) : encoded;
 }
 
-function base64ToText(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
+export function base64ToText(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
   if (!isValidBase64(str, { makeUrlSafe })) {
     throw new Error('Incorrect base64 string');
   }
@@ -25,11 +23,11 @@ function base64ToText(str: string, { makeUrlSafe = false }: { makeUrlSafe?: bool
   }
 }
 
-function removePotentialDataAndMimePrefix(str: string) {
+export function removePotentialDataAndMimePrefix(str: string) {
   return str.replace(/^data:.*?;base64,/, '');
 }
 
-function isValidBase64(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
+export function isValidBase64(str: string, { makeUrlSafe = false }: { makeUrlSafe?: boolean } = {}) {
   let cleanStr = removePotentialDataAndMimePrefix(str);
   if (makeUrlSafe) {
     cleanStr = unURI(cleanStr);

--- a/src/utils/boolean.ts
+++ b/src/utils/boolean.ts
@@ -1,6 +1,4 @@
-export { booleanToHumanReadable, isNotThrowing };
-
-function isNotThrowing(cb: () => unknown): boolean {
+export function isNotThrowing(cb: () => unknown): boolean {
   try {
     cb();
     return true;
@@ -10,6 +8,6 @@ function isNotThrowing(cb: () => unknown): boolean {
   }
 }
 
-function booleanToHumanReadable(value: boolean): string {
+export function booleanToHumanReadable(value: boolean): string {
   return value ? 'Yes' : 'No';
 }

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -1,6 +1,4 @@
-export { withDefaultOnError, withDefaultOnErrorAsync };
-
-function withDefaultOnError<A, B>(cb: () => A, defaultValue: B): A | B {
+export function withDefaultOnError<A, B>(cb: () => A, defaultValue: B): A | B {
   try {
     return cb();
   }
@@ -9,7 +7,7 @@ function withDefaultOnError<A, B>(cb: () => A, defaultValue: B): A | B {
   }
 }
 
-async function withDefaultOnErrorAsync<A, B>(cb: () => A, defaultValue: B): Promise<Awaited<A> | B> {
+export async function withDefaultOnErrorAsync<A, B>(cb: () => A, defaultValue: B): Promise<Awaited<A> | B> {
   try {
     return await cb();
   }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,8 +1,6 @@
 import _ from 'lodash';
 
-export { getErrorMessageIfThrows };
-
-function getErrorMessageIfThrows(cb: () => unknown) {
+export function getErrorMessageIfThrows(cb: () => unknown) {
   try {
     cb();
     return undefined;

--- a/src/utils/macAddress.ts
+++ b/src/utils/macAddress.ts
@@ -1,32 +1,30 @@
 import type { Ref } from 'vue';
 import { useValidation } from '@/composable/validation';
 
-const macAddressValidationRules = [
+export const macAddressValidationRules = [
   {
     message: 'Invalid MAC address',
     validator: (value: string) => value.trim().match(/^([0-9A-F]{2}[:-]){2,5}([0-9A-F]{2})$/i),
   },
 ];
 
-function macAddressValidation(value: Ref) {
+export function macAddressValidation(value: Ref) {
   return useValidation({
     source: value,
     rules: macAddressValidationRules,
   });
 }
 
-const partialMacAddressValidationRules = [
+export const partialMacAddressValidationRules = [
   {
     message: 'Invalid partial MAC address',
     validator: (value: string) => value.trim().match(/^([0-9a-f]{2}[:\-. ]){0,5}([0-9a-f]{0,2})$/i),
   },
 ];
 
-function usePartialMacAddressValidation(value: Ref) {
+export function usePartialMacAddressValidation(value: Ref) {
   return useValidation({
     source: value,
     rules: partialMacAddressValidationRules,
   });
 }
-
-export { macAddressValidation, macAddressValidationRules, partialMacAddressValidationRules, usePartialMacAddressValidation };

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,6 +1,6 @@
-const random = () => Math.random();
+export const random = () => Math.random();
 
-function randFromArray<T>(array: T[]): T {
+export function randFromArray<T>(array: T[]): T {
   const index = Math.floor(random() * array.length);
   const value = array[index];
   if (value === undefined) {
@@ -9,10 +9,10 @@ function randFromArray<T>(array: T[]): T {
   return value;
 }
 
-const randIntFromInterval = (min: number, max: number) => Math.floor(random() * (max - min) + min);
+export const randIntFromInterval = (min: number, max: number) => Math.floor(random() * (max - min) + min);
 
 // Durstenfeld shuffle
-function shuffleArrayMutate<T>(array: T[]): T[] {
+export function shuffleArrayMutate<T>(array: T[]): T[] {
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = array[i];
@@ -26,18 +26,8 @@ function shuffleArrayMutate<T>(array: T[]): T[] {
   return array;
 }
 
-const shuffleArray = <T>(array: T[]): T[] => shuffleArrayMutate([...array]);
+export const shuffleArray = <T>(array: T[]): T[] => shuffleArrayMutate([...array]);
 
-const shuffleString = (str: string, delimiter = ''): string => shuffleArrayMutate(str.split(delimiter)).join(delimiter);
+export const shuffleString = (str: string, delimiter = ''): string => shuffleArrayMutate(str.split(delimiter)).join(delimiter);
 
-const generateRandomId = () => `id-${random().toString(36).substring(2, 12)}`;
-
-export {
-  generateRandomId,
-  randFromArray,
-  randIntFromInterval,
-  random,
-  shuffleArray,
-  shuffleArrayMutate,
-  shuffleString,
-};
+export const generateRandomId = () => `id-${random().toString(36).substring(2, 12)}`;


### PR DESCRIPTION
### Description

Resolves the ~35 CodeQL `js/use-before-declaration` ("Variable not declared before use") findings. They all came from the codebase's `export { … }`-block-at-top convention, which references declarations further down the file:

```diff
-export { convertTomlToJson, isValidToml };
-
-function convertTomlToJson(rawToml: string): string { … }
+export function convertTomlToJson(rawToml: string): string { … }
```

Function declarations are hoisted, so this was correct at runtime — the finding is a readability rule, not a bug. But rather than dismiss it, this converts the pattern to inline `export` on the declaration itself, which removes the findings at the source.

**Scope:** 90 files — `src/tools/*.service.ts`, `src/composable/*`, `src/utils/*` — applied via a codemod (`export function` / `export const` / `export interface` / `export type`). Net **−259 lines**.

**Intentionally left as `export { … }`:** re-exports of *imported* symbols, where the import already precedes the export so there's no use-before-declaration:
- `hmac-generator` → `export type { Encoding }` (imported from `hash-text.service`)
- `downloadBase64` → `export { getExtensionFromMimeType, getMimeTypeFromExtension }` (mime-types aliases)

**Docs:** updated the tool-service template in `CLAUDE.md` to document the inline-export convention (with a note on why, so the pattern doesn't creep back).

### Validation
- `pnpm typecheck` ✅ (the real gate — confirms all 233 inlined exports resolve, no dupes/missing)
- `pnpm lint` ✅ (antfu config)
- full unit suite — **1216 pass** ✅
- production build ✅

### Additional context

Purely mechanical (export placement); no runtime behavior change. Chose this (option C from our discussion) over dismissing the rule so the code no longer trips it and the convention is documented going forward.

---

### What is the purpose of this pull request?

- [x] Other (code-quality refactor — clears CodeQL findings)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated: typecheck, lint, full unit suite, and build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_