### PR TITLE
refactor(home): replace abandoned vuedraggable with vue-draggable-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,10 +105,10 @@
     "uuid": "14.0.1",
     "valibot": "1.4.2",
     "vue": "3.5.41",
+    "vue-draggable-plus": "0.6.1",
     "vue-i18n": "11.4.8",
     "vue-router": "5.2.0",
     "vue-shadow-dom": "4.2.0",
-    "vuedraggable": "4.1.0",
     "xml-formatter": "3.7.0",
     "xml-js": "1.6.11",
     "yaml": "2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       vue:
         specifier: 3.5.41
         version: 3.5.41(typescript@6.0.3)
+      vue-draggable-plus:
+        specifier: 0.6.1
+        version: 0.6.1(@types/sortablejs@1.15.9)
       vue-i18n:
         specifier: 11.4.8
         version: 11.4.8(vue@3.5.41(typescript@6.0.3))
@@ -204,9 +207,6 @@ importers:
       vue-shadow-dom:
         specifier: 4.2.0
         version: 4.2.0
-      vuedraggable:
-        specifier: 4.1.0
-        version: 4.1.0(vue@3.5.41(typescript@6.0.3))
       xml-formatter:
         specifier: 3.7.0
         version: 3.7.0
@@ -2293,6 +2293,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/sortablejs@1.15.9':
+    resolution: {integrity: sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -5360,9 +5363,6 @@ packages:
   snake-case@2.1.0:
     resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
 
-  sortablejs@1.14.0:
-    resolution: {integrity: sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6028,6 +6028,15 @@ packages:
   vue-component-type-helpers@3.3.9:
     resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
+  vue-draggable-plus@0.6.1:
+    resolution: {integrity: sha512-FbtQ/fuoixiOfTZzG3yoPl4JAo9HJXRHmBQZFB9x2NYCh6pq0TomHf7g5MUmpaDYv+LU2n6BPq2YN9sBO+FbIg==}
+    peerDependencies:
+      '@types/sortablejs': ^1.15.0
+      '@vue/composition-api': '*'
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-eslint-parser@10.4.1:
     resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6074,11 +6083,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  vuedraggable@4.1.0:
-    resolution: {integrity: sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==}
-    peerDependencies:
-      vue: ^3.0.1
 
   vueuc@0.4.65:
     resolution: {integrity: sha512-lXuMl+8gsBmruudfxnMF9HW4be8rFziylXFu1VHVNbLVhRTXXV4njvpRuJapD/8q+oFEMSfQMH16E/85VoWRyQ==}
@@ -8125,6 +8129,8 @@ snapshots:
       '@types/node': 24.13.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/sortablejs@1.15.9': {}
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -11817,8 +11823,6 @@ snapshots:
     dependencies:
       no-case: 2.3.2
 
-  sortablejs@1.14.0: {}
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -12525,6 +12529,10 @@ snapshots:
 
   vue-component-type-helpers@3.3.9: {}
 
+  vue-draggable-plus@0.6.1(@types/sortablejs@1.15.9):
+    dependencies:
+      '@types/sortablejs': 1.15.9
+
   vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -12597,11 +12605,6 @@ snapshots:
       '@vue/shared': 3.5.41
     optionalDependencies:
       typescript: 6.0.3
-
-  vuedraggable@4.1.0(vue@3.5.41(typescript@6.0.3)):
-    dependencies:
-      sortablejs: 1.14.0
-      vue: 3.5.41(typescript@6.0.3)
 
   vueuc@0.4.65(vue@3.5.41(typescript@6.0.3)):
     dependencies:

--- a/src/pages/Home.page.vue
+++ b/src/pages/Home.page.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { IconDragDrop, IconHeart } from '@tabler/icons-vue';
 import { useHead } from '@unhead/vue';
-import { computed } from 'vue';
-import Draggable from 'vuedraggable';
+import { ref, watch } from 'vue';
+import { VueDraggable } from 'vue-draggable-plus';
 import ColoredCard from '../components/ColoredCard.vue';
 import ToolCard from '../components/ToolCard.vue';
 import { useToolStore } from '@/tools/tools.store';
@@ -13,7 +13,12 @@ const toolStore = useToolStore();
 useHead({ title: 'IT Tools - Handy online tools for developers' });
 const { t } = useI18n();
 
-const favoriteTools = computed(() => toolStore.favoriteTools);
+// Local, reorderable copy backing the drag-and-drop v-model; kept in sync with
+// the store, with the new order persisted back on drag end.
+const favoriteTools = ref([...toolStore.favoriteTools]);
+watch(() => toolStore.favoriteTools, (tools) => {
+  favoriteTools.value = [...tools];
+});
 
 // Update favorite tools order when drag is finished
 function onUpdateFavoriteTools() {
@@ -53,17 +58,14 @@ function onUpdateFavoriteTools() {
               <n-icon :component="IconDragDrop" size="18" />
             </c-tooltip>
           </h3>
-          <Draggable
-            :list="favoriteTools"
+          <VueDraggable
+            v-model="favoriteTools"
             class="grid grid-cols-1 gap-12px lg:grid-cols-3 md:grid-cols-3 sm:grid-cols-2 xl:grid-cols-4"
             ghost-class="ghost-favorites-draggable"
-            item-key="name"
             @end="onUpdateFavoriteTools"
           >
-            <template #item="{ element: tool }">
-              <ToolCard :tool="tool" />
-            </template>
-          </Draggable>
+            <ToolCard v-for="tool in favoriteTools" :key="tool.name" :tool="tool" />
+          </VueDraggable>
         </div>
       </transition>
 


### PR DESCRIPTION
### Description

Next Tier-2 replacement from #869. `vuedraggable` (v4, last release 2020, unmaintained) → **`vue-draggable-plus`** 0.6.1 (actively maintained, Vue 3 + TS). Used in exactly one place: the favorites drag-and-drop reorder on the home page.

**Not a drop-in** — `vue-draggable-plus`'s `VueDraggable` uses `v-model` + plain `v-for` children instead of vuedraggable's `:list` + `item-key` + `#item` scoped slot:

```diff
-<Draggable :list="favoriteTools" item-key="name" ghost-class="…" @end="onUpdateFavoriteTools">
-  <template #item="{ element: tool }"><ToolCard :tool="tool" /></template>
-</Draggable>
+<VueDraggable v-model="favoriteTools" ghost-class="…" @end="onUpdateFavoriteTools">
+  <ToolCard v-for="tool in favoriteTools" :key="tool.name" :tool="tool" />
+</VueDraggable>
```

`favoriteTools` was a read-only `computed` over the store, but `v-model` needs a writable binding — so it's now a local `ref` kept in sync with the store via `watch`, with the new order persisted on drag end (the existing `onUpdateFavoriteTools` is unchanged). `ghost-class` and `@end` carry over as-is.

### Validation
- `pnpm typecheck`, `pnpm lint`, and production `pnpm build` all pass
- the favorites drag UI (a `.vue` page) is covered by the e2e + visual-regression suites this change triggers — they'll confirm the grid renders identically and reordering still works

Closes the `vuedraggable` item in #869.

### Additional context

After this, the only remaining Tier-2 item is `xml-js` → `fast-xml-parser`, which I'm still holding on pending your OK — it changes the JSON↔XML tools' output format (user-facing), unlike the contained swaps done so far.

---

### What is the purpose of this pull request?

- [x] Other (dependency replacement — drops abandonware)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Include relevant tests / validation: typecheck, lint, and build verified locally; drag UI covered by e2e/visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_