### PR TITLE
refactor: inline exports in models/helpers (finish CodeQL use-before-declaration)

### DIFF
--- a/scripts/shared/changelog.mjs
+++ b/scripts/shared/changelog.mjs
@@ -1,8 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 
-export { addToChangelog };
-
-async function addToChangelog({ changelog, version, changelogPath = './CHANGELOG.md' }) {
+export async function addToChangelog({ changelog, version, changelogPath = './CHANGELOG.md' }) {
   const changelogContent = await readFile(changelogPath, 'utf-8');
   const versionTitle = `## Version ${version}`;
 

--- a/scripts/shared/commits.mjs
+++ b/scripts/shared/commits.mjs
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 
-export { rawCommitsToMarkdown };
-
 const commitScopesToHumanReadable = {
   build: 'Build system',
   chore: 'Chores',
@@ -41,7 +39,7 @@ function commitSectionsToMarkdown({ type, commits }) {
   ].join('\n');
 }
 
-function rawCommitsToMarkdown({ rawCommits }) {
+export function rawCommitsToMarkdown({ rawCommits }) {
   return _.chain(rawCommits)
     .trim()
     .split('\n')

--- a/src/composable/computed/catchedComputed.ts
+++ b/src/composable/computed/catchedComputed.ts
@@ -1,10 +1,8 @@
 import type { Ref } from 'vue';
 import { ref, watchEffect } from 'vue';
 
-export { computedCatch };
-
-function computedCatch<T, D>(getter: () => T, { defaultValue }: { defaultValue: D; defaultErrorMessage?: string }): [Ref<T | D>, Ref<string | undefined>];
-function computedCatch<T, D>(getter: () => T, { defaultValue, defaultErrorMessage = 'Unknown error' }: { defaultValue?: D; defaultErrorMessage?: string } = {}) {
+export function computedCatch<T, D>(getter: () => T, { defaultValue }: { defaultValue: D; defaultErrorMessage?: string }): [Ref<T | D>, Ref<string | undefined>];
+export function computedCatch<T, D>(getter: () => T, { defaultValue, defaultErrorMessage = 'Unknown error' }: { defaultValue?: D; defaultErrorMessage?: string } = {}) {
   const error = ref<string | undefined>();
   const value = ref<T | D | undefined>();
 

--- a/src/modules/shared/date.models.ts
+++ b/src/modules/shared/date.models.ts
@@ -1,7 +1,5 @@
 import { format } from 'date-fns';
 
-export { getUrlFriendlyDateTime };
-
-function getUrlFriendlyDateTime({ date = new Date() }: { date?: Date } = {}) {
+export function getUrlFriendlyDateTime({ date = new Date() }: { date?: Date } = {}) {
   return format(date, 'yyyy-MM-dd-HH-mm-ss');
 }

--- a/src/modules/shared/number.models.ts
+++ b/src/modules/shared/number.models.ts
@@ -1,5 +1,3 @@
-function clamp({ value, min = 0, max = 100 }: { value: number; min?: number; max?: number }) {
+export function clamp({ value, min = 0, max = 100 }: { value: number; min?: number; max?: number }) {
   return Math.min(Math.max(value, min), max);
 }
-
-export { clamp };

--- a/src/tools/benchmark-builder/benchmark-builder.models.ts
+++ b/src/tools/benchmark-builder/benchmark-builder.models.ts
@@ -1,8 +1,6 @@
 import _ from 'lodash';
 
-export { arrayToMarkdownTable, computeAverage, computeVariance };
-
-function computeAverage({ data }: { data: number[] }) {
+export function computeAverage({ data }: { data: number[] }) {
   if (data.length === 0) {
     return 0;
   }
@@ -10,7 +8,7 @@ function computeAverage({ data }: { data: number[] }) {
   return _.sum(data) / data.length;
 }
 
-function computeVariance({ data }: { data: number[] }) {
+export function computeVariance({ data }: { data: number[] }) {
   const mean = computeAverage({ data });
 
   const squaredDiffs = data.map(value => (value - mean) ** 2);
@@ -18,7 +16,7 @@ function computeVariance({ data }: { data: number[] }) {
   return computeAverage({ data: squaredDiffs });
 }
 
-function arrayToMarkdownTable({ data, headerMap = {} }: { data: Record<string, unknown>[]; headerMap?: Record<string, string> }) {
+export function arrayToMarkdownTable({ data, headerMap = {} }: { data: Record<string, unknown>[]; headerMap?: Record<string, string> }) {
   if (!Array.isArray(data) || data.length === 0) {
     return '';
   }

--- a/src/tools/bip39-generator/bip39.ts
+++ b/src/tools/bip39-generator/bip39.ts
@@ -8,9 +8,7 @@ import type { WordList } from './wordlists';
 // (16-32 chars) is validated, matching the original.
 import { sha256 } from '@noble/hashes/sha2.js';
 
-export { entropyToMnemonic, generateEntropy, mnemonicToEntropy, validateEntropyLength };
-
-function validateEntropyLength(length: number): void {
+export function validateEntropyLength(length: number): void {
   if (length < 16) {
     throw new Error('[bip39] Invalid entropy: the length of the entropy string should be >= 16 ');
   }
@@ -22,7 +20,7 @@ function validateEntropyLength(length: number): void {
   }
 }
 
-function generateEntropy(length = 32): string {
+export function generateEntropy(length = 32): string {
   validateEntropyLength(length);
 
   const bytes = new Uint8Array(length / 2);
@@ -31,7 +29,7 @@ function generateEntropy(length = 32): string {
   return bytesToHexString(bytes);
 }
 
-function entropyToMnemonic(entropy: string, wordList: WordList): string {
+export function entropyToMnemonic(entropy: string, wordList: WordList): string {
   validateEntropyLength(entropy.length);
 
   if (!entropy.match(/^[a-z0-9]+$/i)) {
@@ -45,7 +43,7 @@ function entropyToMnemonic(entropy: string, wordList: WordList): string {
     .join(wordList.spacer);
 }
 
-function mnemonicToEntropy(mnemonic: string, wordList: WordList): string {
+export function mnemonicToEntropy(mnemonic: string, wordList: WordList): string {
   const bits = mnemonic
     .trim()
     .split(wordList.spacer)

--- a/src/tools/camera-recorder/useMediaRecorder.ts
+++ b/src/tools/camera-recorder/useMediaRecorder.ts
@@ -1,9 +1,7 @@
 import type { Ref } from 'vue';
 import { computed, ref } from 'vue';
 
-export { useMediaRecorder };
-
-function useMediaRecorder({ stream }: { stream: Ref<MediaStream | undefined> }): {
+export function useMediaRecorder({ stream }: { stream: Ref<MediaStream | undefined> }): {
   isRecordingSupported: Ref<boolean>;
   recordingState: Ref<'stopped' | 'recording' | 'paused'>;
   startRecording: () => void;

--- a/src/tools/color-converter/color-converter.models.ts
+++ b/src/tools/color-converter/color-converter.models.ts
@@ -4,13 +4,11 @@ import { ref } from 'vue';
 import { useValidation } from '@/composable/validation';
 import { withDefaultOnError } from '@/utils/defaults';
 
-export { buildColorFormat, removeAlphaChannelWhenOpaque };
-
-function removeAlphaChannelWhenOpaque(hexColor: string) {
+export function removeAlphaChannelWhenOpaque(hexColor: string) {
   return hexColor.replace(/^(#(?:[0-9a-f]{3}){1,2})ff$/i, '$1');
 }
 
-function buildColorFormat({
+export function buildColorFormat({
   label,
   parse = value => colord(value),
   format,

--- a/src/tools/date-time-converter/date-time-converter.models.ts
+++ b/src/tools/date-time-converter/date-time-converter.models.ts
@@ -1,19 +1,5 @@
 import _ from 'lodash';
 
-export {
-  dateToExcelFormat,
-  excelFormatToDate,
-  isExcelFormat,
-  isISO8601DateTimeString,
-  isISO9075DateString,
-  isMongoObjectId,
-  isRFC3339DateString,
-  isRFC7231DateString,
-  isTimestamp,
-  isUnixTimestamp,
-  isUTCDateString,
-};
-
 const ISO8601_REGEX
   = /^([+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([.,]\d+)?)?(:?[0-5]\d([.,]\d+)?)?([zZ]|([+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
 const ISO9075_REGEX
@@ -30,17 +16,17 @@ function createRegexMatcher(regex: RegExp) {
   return (date?: string) => !_.isNil(date) && regex.test(date);
 }
 
-const isISO8601DateTimeString = createRegexMatcher(ISO8601_REGEX);
-const isISO9075DateString = createRegexMatcher(ISO9075_REGEX);
-const isRFC3339DateString = createRegexMatcher(RFC3339_REGEX);
-const isRFC7231DateString = createRegexMatcher(RFC7231_REGEX);
-const isUnixTimestamp = createRegexMatcher(/^\d{1,10}$/);
-const isTimestamp = createRegexMatcher(/^\d{1,13}$/);
-const isMongoObjectId = createRegexMatcher(/^[0-9a-f]{24}$/i);
+export const isISO8601DateTimeString = createRegexMatcher(ISO8601_REGEX);
+export const isISO9075DateString = createRegexMatcher(ISO9075_REGEX);
+export const isRFC3339DateString = createRegexMatcher(RFC3339_REGEX);
+export const isRFC7231DateString = createRegexMatcher(RFC7231_REGEX);
+export const isUnixTimestamp = createRegexMatcher(/^\d{1,10}$/);
+export const isTimestamp = createRegexMatcher(/^\d{1,13}$/);
+export const isMongoObjectId = createRegexMatcher(/^[0-9a-f]{24}$/i);
 
-const isExcelFormat = createRegexMatcher(EXCEL_FORMAT_REGEX);
+export const isExcelFormat = createRegexMatcher(EXCEL_FORMAT_REGEX);
 
-function isUTCDateString(date?: string) {
+export function isUTCDateString(date?: string) {
   if (_.isNil(date)) {
     return false;
   }
@@ -53,10 +39,10 @@ function isUTCDateString(date?: string) {
   }
 }
 
-function dateToExcelFormat(date: Date) {
+export function dateToExcelFormat(date: Date) {
   return String(((date.getTime()) / (1000 * 60 * 60 * 24)) + 25569);
 }
 
-function excelFormatToDate(excelFormat: string | number) {
+export function excelFormatToDate(excelFormat: string | number) {
   return new Date((Number(excelFormat) - 25569) * 86400 * 1000);
 }

--- a/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.models.ts
+++ b/src/tools/ipv4-subnet-calculator/ipv4-subnet-calculator.models.ts
@@ -1,6 +1,4 @@
-export { getIPClass };
-
-function getIPClass({ ip }: { ip: string }) {
+export function getIPClass({ ip }: { ip: string }) {
   const [firstOctet] = ip.split('.').map(Number);
 
   if (firstOctet === undefined) {

--- a/src/tools/json-diff/json-diff.models.ts
+++ b/src/tools/json-diff/json-diff.models.ts
@@ -1,9 +1,7 @@
 import type { Difference, DifferenceStatus } from './json-diff.types';
 import _ from 'lodash';
 
-export { diff };
-
-function diff(
+export function diff(
   obj: unknown,
   newObj: unknown,
   { onlyShowDifferences = false }: { onlyShowDifferences?: boolean } = {},

--- a/src/tools/json-viewer/json.models.ts
+++ b/src/tools/json-viewer/json.models.ts
@@ -2,9 +2,7 @@ import type { MaybeRef } from 'vue';
 import { get } from '@vueuse/core';
 import JSON5 from 'json5';
 
-export { formatJson, sortObjectKeys };
-
-function sortObjectKeys<T>(obj: T): T {
+export function sortObjectKeys<T>(obj: T): T {
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
@@ -21,7 +19,7 @@ function sortObjectKeys<T>(obj: T): T {
     }, {} as Record<string, unknown>) as T;
 }
 
-function formatJson({
+export function formatJson({
   rawJson,
   sortKeys = true,
   indentSize = 3,

--- a/src/tools/jsonpath-query/jsonpath.engine.ts
+++ b/src/tools/jsonpath-query/jsonpath.engine.ts
@@ -15,8 +15,6 @@
 // && || ! , parentheses, and number / string / boolean / null literals.
 // A bare path in a filter is an existence test. No eval is used anywhere.
 
-export { evaluateJsonPath };
-
 type Json = unknown;
 
 interface NameSelector { type: 'name'; name: string }
@@ -36,7 +34,7 @@ type Selector
 
 interface Step { recursive: boolean; selector: Selector }
 
-function evaluateJsonPath({ path, json }: { path: string; json: Json }): Json[] {
+export function evaluateJsonPath({ path, json }: { path: string; json: Json }): Json[] {
   const steps = parsePath(path);
 
   let current: Json[] = [json];

--- a/src/tools/list-converter/list-converter.models.ts
+++ b/src/tools/list-converter/list-converter.models.ts
@@ -2,14 +2,12 @@ import type { ConvertOptions } from './list-converter.types';
 import _ from 'lodash';
 import { byOrder } from '@/utils/array';
 
-export { convert };
-
 function whenever<T, R>(condition: boolean, fn: (value: T) => R) {
   return (value: T) =>
     condition ? fn(value) : value;
 }
 
-function convert(list: string, options: ConvertOptions): string {
+export function convert(list: string, options: ConvertOptions): string {
   const lineBreak = options.keepLineBreaks ? '\n' : '';
 
   return _.chain(list)

--- a/src/tools/mac-address-generator/mac-adress-generator.models.ts
+++ b/src/tools/mac-address-generator/mac-adress-generator.models.ts
@@ -1,14 +1,12 @@
 import _ from 'lodash';
 
-export { generateRandomMacAddress, splitPrefix };
-
-function splitPrefix(prefix: string): string[] {
+export function splitPrefix(prefix: string): string[] {
   const base = prefix.match(/[^0-9a-f]/i) === null ? prefix.match(/.{1,2}/g) ?? [] : prefix.split(/[^0-9a-f]/i);
 
   return base.filter(Boolean).map(byte => byte.padStart(2, '0'));
 }
 
-function generateRandomMacAddress({ prefix: rawPrefix = '', separator = ':', getRandomByte = () => _.random(0, 255).toString(16).padStart(2, '0') }: { prefix?: string; separator?: string; getRandomByte?: () => string } = {}) {
+export function generateRandomMacAddress({ prefix: rawPrefix = '', separator = ':', getRandomByte = () => _.random(0, 255).toString(16).padStart(2, '0') }: { prefix?: string; separator?: string; getRandomByte?: () => string } = {}) {
   const prefix = splitPrefix(rawPrefix);
 
   const randomBytes = _.times(6 - prefix.length, getRandomByte);

--- a/src/tools/meta-tag-generator/OGSchemaType.type.ts
+++ b/src/tools/meta-tag-generator/OGSchemaType.type.ts
@@ -1,27 +1,25 @@
 import type { SelectGroupOption, SelectOption } from 'naive-ui';
 
-export type { OGSchemaType, OGSchemaTypeElementInput, OGSchemaTypeElementInputMultiple, OGSchemaTypeElementSelect };
-
 interface OGSchemaTypeElementBase {
   key: string;
   label: string;
   placeholder: string;
 }
 
-interface OGSchemaTypeElementInput extends OGSchemaTypeElementBase {
+export interface OGSchemaTypeElementInput extends OGSchemaTypeElementBase {
   type: 'input';
 }
 
-interface OGSchemaTypeElementInputMultiple extends OGSchemaTypeElementBase {
+export interface OGSchemaTypeElementInputMultiple extends OGSchemaTypeElementBase {
   type: 'input-multiple';
 }
 
-interface OGSchemaTypeElementSelect extends OGSchemaTypeElementBase {
+export interface OGSchemaTypeElementSelect extends OGSchemaTypeElementBase {
   type: 'select';
   options: Array<SelectOption | SelectGroupOption>;
 }
 
-interface OGSchemaType {
+export interface OGSchemaType {
   name: string;
   elements: (OGSchemaTypeElementSelect | OGSchemaTypeElementInput | OGSchemaTypeElementInputMultiple)[];
 }

--- a/src/tools/meta-tag-generator/oggen.ts
+++ b/src/tools/meta-tag-generator/oggen.ts
@@ -4,12 +4,9 @@
 // tags carry their data in the `content` attribute (what OG/Twitter crawlers
 // read), not `value` - the original emitted the invalid `value="..."`.
 
-export type { MetadataConfig, MetadataValue };
-export { generateMeta };
+export type MetadataValue = boolean | string | Date | number;
 
-type MetadataValue = boolean | string | Date | number;
-
-interface MetadataConfig {
+export interface MetadataConfig {
   [key: string]: MetadataValue | MetadataValue[] | MetadataConfig;
 }
 
@@ -26,7 +23,7 @@ const twitterCompatibility: Record<string, string> = {
   'og:image:alt': 'twitter:image:alt',
 };
 
-function generateMeta(
+export function generateMeta(
   { twitter: twitterMetadataRaw, ...ogMetadataRaw }: MetadataConfig,
   { indentation = 0, indentWith = '  ', generateTwitterCompatibleMeta = false }: { indentation?: number; indentWith?: string; generateTwitterCompatibleMeta?: boolean } = {},
 ): string {

--- a/src/tools/ocr-image-to-text/ocr-image-to-text.pdf.ts
+++ b/src/tools/ocr-image-to-text/ocr-image-to-text.pdf.ts
@@ -8,13 +8,11 @@ import PdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 // to users who actually process a PDF.
 import './map-upsert.polyfill';
 
-export { renderPdfToImages };
-
 GlobalWorkerOptions.workerSrc = PdfWorkerUrl;
 
 // Higher scale -> sharper render -> better OCR, at the cost of memory/time. 2x
 // is a good default for screen-resolution PDFs.
-async function renderPdfToImages(file: File | ArrayBuffer, { scale = 2 }: { scale?: number } = {}): Promise<Blob[]> {
+export async function renderPdfToImages(file: File | ArrayBuffer, { scale = 2 }: { scale?: number } = {}): Promise<Blob[]> {
   const data = file instanceof File ? await file.arrayBuffer() : file;
   const loadingTask = getDocument({ data });
   const pdf = await loadingTask.promise;

--- a/src/tools/string-obfuscator/string-obfuscator.model.ts
+++ b/src/tools/string-obfuscator/string-obfuscator.model.ts
@@ -2,9 +2,7 @@ import type { MaybeRef } from 'vue';
 import { get } from '@vueuse/core';
 import { computed } from 'vue';
 
-export { obfuscateString, useObfuscateString };
-
-function obfuscateString(
+export function obfuscateString(
   str: string,
   { replacementChar = '*', keepFirst = 4, keepLast = 0, keepSpace = true }: { replacementChar?: string; keepFirst?: number; keepLast?: number; keepSpace?: boolean } = {},
 ): string {
@@ -20,7 +18,7 @@ function obfuscateString(
     .join('');
 }
 
-function useObfuscateString(
+export function useObfuscateString(
   str: MaybeRef<string>,
   config: { replacementChar?: MaybeRef<string>; keepFirst?: MaybeRef<number>; keepLast?: MaybeRef<number>; keepSpace?: MaybeRef<boolean> } = {},
 

--- a/src/tools/text-to-binary/text-to-binary.models.ts
+++ b/src/tools/text-to-binary/text-to-binary.models.ts
@@ -1,13 +1,11 @@
-export { convertAsciiBinaryToText, convertTextToAsciiBinary };
-
-function convertTextToAsciiBinary(text: string, { separator = ' ' }: { separator?: string } = {}): string {
+export function convertTextToAsciiBinary(text: string, { separator = ' ' }: { separator?: string } = {}): string {
   return text
     .split('')
     .map(char => char.charCodeAt(0).toString(2).padStart(8, '0'))
     .join(separator);
 }
 
-function convertAsciiBinaryToText(binary: string): string {
+export function convertAsciiBinaryToText(binary: string): string {
   const cleanBinary = binary.replace(/[^01]/g, '');
 
   if (cleanBinary.length % 8) {

--- a/src/ui/color/color.models.ts
+++ b/src/ui/color/color.models.ts
@@ -1,8 +1,6 @@
-export { darken, lighten, setOpacity };
-
 const clampHex = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
 
-function lighten(color: string, amount: number): string {
+export function lighten(color: string, amount: number): string {
   const alpha = color.length === 9 ? color.slice(7) : '';
   const num = Number.parseInt(color.slice(1, 7), 16);
 
@@ -13,11 +11,11 @@ function lighten(color: string, amount: number): string {
   return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}${alpha}`;
 }
 
-function darken(color: string, amount: number): string {
+export function darken(color: string, amount: number): string {
   return lighten(color, -amount);
 }
 
-function setOpacity(color: string, opacity: number): string {
+export function setOpacity(color: string, opacity: number): string {
   const alpha = clampHex(Math.round(opacity * 255))
     .toString(16)
     .padStart(2, '0');

--- a/src/ui/theme/theme.models.ts
+++ b/src/ui/theme/theme.models.ts
@@ -1,8 +1,6 @@
 import { useStyleStore } from '@/stores/style.store';
 
-export { defineThemes };
-
-function defineThemes<Theme>(themes: { light: Theme; dark: Theme }) {
+export function defineThemes<Theme>(themes: { light: Theme; dark: Theme }) {
   return {
     themes,
     useTheme() {


### PR DESCRIPTION
### Description

Finishes the CodeQL `js/use-before-declaration` cleanup. #885 converted `*.service.ts` (+ top-level composable/utils), but the same `export { … }`-block-before-declaration pattern remained in **`*.models.ts` and other helpers** — which is why CodeQL still flagged files like `date-time-converter.models.ts`.

Ran the same codemod over the remaining 23 files:
- `*.models.ts` / `*.model.ts` / `*.type.ts` across `src/tools`, `src/modules/shared`, `src/ui`
- helpers: `oggen.ts`, `useMediaRecorder.ts`, `useQRCode.ts`, `bip39.ts`, `jsonpath.engine.ts`, `ocr-image-to-text.pdf.ts`
- a nested `src/composable/computed/catchedComputed.ts` that #885's `src/composable/*.ts` glob missed
- `scripts/shared/{changelog,commits}.mjs`

Each top-level `export { … }` block became inline `export` on the declaration.

**Handled edge cases:**
- `catchedComputed.ts` is an **overloaded** function — exported both the overload signature and the implementation (TS2383: overloads must share export-ness).
- Left untouched (correctly — not use-before-declaration): `export { … } from './…'` **re-exports** (`useQRCode`) and re-exports of **imported** symbols (`downloadBase64`, `hmac-generator`).

### Validation
- `pnpm typecheck`, `pnpm lint`, full unit suite (**1216 pass**), and production build — all green.

### Additional context

Independent of #886 (vuedraggable) — no file overlap, so they merge cleanly in any order. Opened on a separate branch (per your go-ahead) so it isn't blocked behind #886. Together with #885 this clears the entire `use-before-declaration` class.

---

### What is the purpose of this pull request?

- [x] Other (code-quality refactor — clears remaining CodeQL findings)

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving.
- [x] Validated: typecheck, lint, full unit suite, and build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TH2DWHBJVYCch2kdmJ7sT)_